### PR TITLE
FIX GLCM gray-level quantization and texture orientation

### DIFF
--- a/docs/glcm.md
+++ b/docs/glcm.md
@@ -39,7 +39,7 @@ Let an input image array $I$ contain quantized integer gray levels bounded withi
 
 $$\mathcal{G} = \{0, 1, 2, \dots, G-1\}$$
 
-Where $G$ represents the total number of gray levels (for standard 8-bit unsigned integer data, $G = 256$). A spatial offset vector is defined by its coordinate displacements:
+Where $G$ represents the total number of gray levels, set by the `levels` parameter (default $G = 64$). Input rasters are **not** assumed to already lie in $[0, G-1]$: the pipeline quantizes them into that range first, as described under Global Quantization below. A spatial offset vector is defined by its coordinate displacements:
 
 $$\mathbf{d} = (d_x, d_y)$$
 
@@ -127,15 +127,25 @@ $$\sigma_i = \sqrt{\sum_{i=0}^{G-1} \sum_{j=0}^{G-1} (i - \mu_i)^2 \cdot p(i, j)
 └──────────────────────────────┘          skimage per step                    └──────────────────────────────┘
 ```
 
-1. **Quantization Baseline:** The pipeline extracts the single-band raster array (typically the Near-Infrared band) and casts it to an 8-bit unsigned integer array (`uint8`).
-    
-2. **Sliding Window Trajectory:** A square window of user-defined size $W \times W$ slides across the image grid with a horizontal and vertical stride of 1 pixel. The window is anchored at the current pixel $(i, j)$ and extends down and to the right.
-    
-3. **Array Extraction:** For each window position, the local GLCM is extracted, normalized, and evaluated across the selected Haralick property configuration.
-    
-4. **Output Matrix Offset:** The resulting scalar texture metric is written to the upper-left coordinate index $[i, j]$ of the active window position within the output array.
-    
-5. **Border Behavior:** Every output pixel is computed. Near the right and bottom edges the requested $W \times W$ window extends past the image, so NumPy slicing clips it to the remaining pixels (a truncated window). There is no padding, and border pixels are not left uninitialized. Top and left pixels still have a full window because the window extends inward from $(i, j)$.
+1. **Global Quantization:** The pipeline extracts the single-band raster array (typically the Near-Infrared band) and **linearly quantizes** it to `levels` gray levels:
+
+    $$q(x) = \left\lfloor \frac{x - x_{\min}}{x_{\max} - x_{\min}} \cdot (L - 1) \right\rceil$$
+
+    The scaling uses the **whole-image** minimum and maximum, not a per-window range, so a texture value computed in one part of the scene is directly comparable with one computed elsewhere. That comparability is the entire purpose of a texture map: in lithological discrimination the signal is the texture *contrast between units*, which a per-window rescale would erase.
+
+    A constant band quantizes to all zeros. Non-finite pixels are excluded from the range and mapped to level 0.
+
+    > **This is a quantization, not a cast.** Earlier versions applied `numpy.array(..., dtype="uint8")`, which wraps **modulo 256**: DN 3311 became 239 and DN 6200 became 56, so radiometrically adjacent pixels landed at opposite ends of the gray-level range. On the bundled 16-bit example the correlation between the source band and the casted array was **-0.22**, meaning texture was computed on effectively scrambled data. Every 16-bit product — Landsat, Sentinel, ASTER — was affected. Linear quantization is monotonic and preserves gray-level ordering (correlation > 0.999 on the same band).
+
+2. **Sliding Window Trajectory:** A square window of user-defined size $W \times W$ slides across the image grid with a stride of 1 pixel. By default the window is **centered** on the current pixel $(i, j)$.
+
+3. **Array Extraction:** For each window position the local GLCM is built over every requested `distances` × `angles` pair, normalized, and evaluated for the selected Haralick property. The scalar written to the output is the **mean over all pairs**.
+
+4. **Output Matrix Registration:** The texture value for the neighbourhood centered on $(i, j)$ is written to index $[i, j]$, so the texture map stays registered to the source raster grid.
+
+    > **Spatial registration.** With `centered=False` the window is anchored at $(i, j)$ and extends down and to the right, which displaces the whole texture map by $\lfloor (W-1)/2 \rfloor$ pixels up and to the left relative to the input. At 30 m Landsat resolution with $W = 15$ that is a **210 m offset** — a georeferencing error once the result is exported as a georeferenced raster or overlaid on a geological map. The legacy behaviour remains available for reproducing older outputs.
+
+5. **Border Behavior:** Every output pixel is computed. Under the default centered window the array is **reflect-padded** by $\lfloor W/2 \rfloor$, so border pixels are evaluated over a full $W \times W$ neighbourhood rather than a truncated one. With `centered=False` the window is instead clipped at the right and bottom edges, giving those pixels a smaller sample.
 
 ### Interface Architecture
 
@@ -148,9 +158,25 @@ $$\sigma_i = \sqrt{\sum_{i=0}^{G-1} \sum_{j=0}^{G-1} (i - \mu_i)^2 \cdot p(i, j)
 
 $$\text{window\_size} \ge 3$$
 
-- `propery` (`str`): Target Haralick feature name selection. Must match one of the following strings:
+- `property` (`str`): Target Haralick feature name selection. Must match one of the following strings:
     
     - `"contrast"`, `"dissimilarity"`, `"homogeneity"`, `"ASM"`, `"energy"`, `"correlation"`.
+
+    > The original misspelling `propery` is still accepted so existing code keeps working. Passing both raises `ValueError`.
+
+- `levels` (`int`, default `64`): Number of gray levels to quantize to before building the co-occurrence matrix. Must satisfy $2 \le L \le 256$.
+
+    **Choosing this value matters, and 256 is usually the wrong answer.** A $W \times W$ window supplies only $(W-1) \cdot W \cdot 2$ ordered pairs — 12 for $W = 3$, 40 for $W = 5$. Distributing 12 pairs over a $256 \times 256$ matrix populates 0.018% of its cells, and the resulting `contrast` or `correlation` value then describes matrix sparsity rather than surface texture. 32–64 levels is the standard working range for windowed GLCM, which is why the default is 64. Raise `levels` only alongside a larger window.
+
+- `distances` (`Sequence[int]`, default `(1,)`): Pixel offsets $\mathbf{d}$ at which co-occurrence is evaluated. Larger offsets probe coarser texture scales.
+
+- `angles` (`Sequence[float]`, default `(0, \pi/4, \pi/2, 3\pi/4)`): Orientations in radians. Results are **averaged over every distance/angle pair**, which yields a rotation-invariant measure — the correct default for surface roughness and lithological discrimination, where the response should not depend on how the scene happens to be oriented.
+
+    Passing a single angle deliberately makes the measure **anisotropic**, which is what you want when the target is directional: bedding traces, foliation, dune crests or lineament fabric. Comparing the single-angle response across orientations is a way to extract structural azimuth.
+
+    > **Cost.** Texture is evaluated per pixel, so runtime scales with `len(distances) × len(angles)`. The four-angle default is roughly four times the cost of a single orientation.
+
+- `centered` (`bool`, default `True`): Center the analysis window on each pixel. See the spatial registration note above before setting this to `False`.
 
 #### Operational Validation (`_validate`)
 
@@ -158,13 +184,24 @@ The programmatic `_validate()` method enforces runtime constraints prior to code
 
 1. Verifies that `window_size` is an integer and an odd value greater than or equal to 3.
     
-2. Checks that `propery` is a valid string matching one of the six supported Haralick feature types (`contrast`, `dissimilarity`, `homogeneity`, `ASM`, `energy`, `correlation`).
+2. Checks that `property` is a valid string matching one of the six supported Haralick feature types (`contrast`, `dissimilarity`, `homogeneity`, `ASM`, `energy`, `correlation`).
     
-3. Confirms that the target single-band file path exists and is readable.
+3. Verifies that `levels` is an integer in $[2, 256]$.
+
+4. Verifies that `distances` is a non-empty sequence of positive integers and that `angles` is non-empty.
+
+5. Confirms that the target single-band file path exists and is readable.
 
 #### Return State (`process()`)
 
-Returns a 2D `numpy.ndarray` with the same `(height, width)` shape as the input image. Every pixel is assigned a texture value. Pixels whose $W \times W$ window would extend past the right or bottom edge are computed from the truncated in-bounds window rather than from padded or missing data.
+Returns a 2D `numpy.ndarray` with the same `(height, width)` shape as the input image. Every pixel is assigned a texture value, averaged over all requested distance/angle pairs. Under the default centered window every pixel — borders included — is evaluated over a full $W \times W$ neighbourhood via reflect padding.
+
+Progress is emitted through the standard `logging` module at `DEBUG` level on the `fezrs.tools.glcm.glcm_calculator` logger, so it is silent by default. Enable it with:
+
+```Python
+import logging
+logging.getLogger("fezrs.tools.glcm.glcm_calculator").setLevel(logging.DEBUG)
+```
 
 #### Operational Implementation
 
@@ -176,7 +213,8 @@ from fezrs.tools.glcm import GLCMCalculator
 texture_engine = GLCMCalculator(
     nir_path=Path("./data/Landsat8_NIR.tif"),
     window_size=5,
-    propery="homogeneity"
+    property="homogeneity",
+    levels=64,                 # gray levels after quantization
 )
 
 # Run texture pipeline and save output map

--- a/fezrs/tools/glcm/glcm_calculator.py
+++ b/fezrs/tools/glcm/glcm_calculator.py
@@ -1,9 +1,67 @@
+import logging
 import numpy as np
 from pathlib import Path
-from typing import get_args
+from typing import Sequence, get_args
 from fezrs.base import BaseTool
 from skimage.feature import graycomatrix, graycoprops
 from fezrs.utils.type_handler import BandPathType, PropertyGLCMType
+
+
+logger = logging.getLogger(__name__)
+
+
+# Haralick texture is direction dependent. Averaging the four principal
+# orientations yields a rotation invariant measure, which is what a surface
+# roughness or lithological discrimination map needs. A single angle is kept
+# reachable for deliberately anisotropic work (bedding, foliation, lineaments).
+DEFAULT_ANGLES = (0.0, np.pi / 4, np.pi / 2, 3 * np.pi / 4)
+DEFAULT_DISTANCES = (1,)
+
+# Small windows supply very few co-occurrence pairs: a W x W window yields
+# (W - 1) * W * 2 ordered pairs, i.e. 12 for W = 3. Spreading 12 pairs over a
+# 256 x 256 matrix fills 0.018% of it, so the Haralick statistics end up
+# describing matrix sparsity rather than surface texture. 32-64 levels is the
+# usual working range for windowed GLCM.
+DEFAULT_LEVELS = 64
+
+
+def quantize_to_levels(image: np.ndarray, levels: int) -> np.ndarray:
+    """
+    Linearly quantize an image to ``levels`` gray levels in ``[0, levels - 1]``.
+
+    Quantization is global: the scaling uses the whole-image minimum and
+    maximum, so a texture value computed in one part of the scene is comparable
+    with one computed elsewhere. That comparability is the point of a texture
+    map, and a per-window rescale would destroy it.
+
+    This replaces a plain ``astype(np.uint8)``, which wraps modulo 256 and
+    destroys gray-level ordering on any raster holding values above 255 -- that
+    is, on every 16-bit Landsat, Sentinel or ASTER band.
+
+    Args:
+        image: Input array of any numeric dtype.
+        levels: Number of gray levels to quantize to.
+
+    Returns:
+        np.ndarray: ``uint8`` array with values in ``[0, levels - 1]``.
+    """
+    array = np.asarray(image, dtype=np.float64)
+
+    finite = np.isfinite(array)
+    if not finite.any():
+        return np.zeros(array.shape, dtype=np.uint8)
+
+    low = array[finite].min()
+    high = array[finite].max()
+
+    # A constant band carries no texture; every pixel maps to level 0.
+    if high == low:
+        return np.zeros(array.shape, dtype=np.uint8)
+
+    scaled = (array - low) / (high - low) * (levels - 1)
+    scaled = np.where(finite, scaled, 0.0)
+
+    return np.clip(np.round(scaled), 0, levels - 1).astype(np.uint8)
 
 
 class GLCMCalculator(BaseTool):
@@ -11,9 +69,38 @@ class GLCMCalculator(BaseTool):
         self,
         nir_path: BandPathType,
         window_size: int = 3,
-        propery: PropertyGLCMType = "contrast",
+        propery: PropertyGLCMType | None = None,
+        *,
+        property: PropertyGLCMType | None = None,
+        levels: int = DEFAULT_LEVELS,
+        distances: Sequence[int] = DEFAULT_DISTANCES,
+        angles: Sequence[float] = DEFAULT_ANGLES,
+        centered: bool = True,
     ):
+        """
+        Args:
+            nir_path: Single-band raster to compute texture on.
+            window_size: Odd window edge length, >= 3.
+            propery: Deprecated misspelling of ``property``, kept working.
+            property: Haralick property to evaluate.
+            levels: Gray levels to quantize to before building the GLCM.
+            distances: Pixel offsets passed to ``graycomatrix``.
+            angles: Orientations in radians; results are averaged over all of
+                them, and over all distances.
+            centered: Center the window on each pixel. When False, the window is
+                anchored at the pixel and extends down and to the right, which
+                offsets the texture map by ``(window_size - 1) // 2`` pixels
+                relative to the source raster.
+        """
         super().__init__(nir_path=nir_path)
+
+        if propery is not None and property is not None:
+            raise ValueError(
+                "Pass either 'property' or the deprecated 'propery', not both."
+            )
+
+        selected_property = property if property is not None else propery
+        self.property = "contrast" if selected_property is None else selected_property
 
         self.metadata_bands = self.files_handler.get_metadata_bands(
             requested_bands=["nir"]
@@ -23,32 +110,62 @@ class GLCMCalculator(BaseTool):
             (self.metadata_bands["nir"]["height"], self.metadata_bands["nir"]["width"])
         )
 
-        self.nir_image = np.array(
-            self.metadata_bands["nir"]["image_skimage"], dtype="uint8"
-        )
-
-        self.property = propery
         self.window_size = window_size
+        self.levels = levels
+        self.distances = tuple(distances)
+        self.angles = tuple(angles)
+        self.centered = centered
+
+        self.nir_image = quantize_to_levels(
+            self.metadata_bands["nir"]["image_skimage"], self.levels
+        )
 
     def process(self):
         self._validate()
 
         height = self.metadata_bands["nir"]["height"]
         width = self.metadata_bands["nir"]["width"]
+
+        offset = self.window_size // 2
+
+        if self.centered:
+            # Reflect padding keeps every window full size, so border pixels get
+            # a texture value from a complete neighbourhood instead of from a
+            # truncated one, and the window stays centered on its pixel.
+            image = np.pad(self.nir_image, offset, mode="reflect")
+        else:
+            image = self.nir_image
+
+        logger.debug(
+            "GLCM %s over %dx%d, window=%d, levels=%d, distances=%s, angles=%s",
+            self.property,
+            height,
+            width,
+            self.window_size,
+            self.levels,
+            self.distances,
+            self.angles,
+        )
+
         for i in range(0, height):
-            print(f"Processing row {i} of {height}")
+            logger.debug("Processing row %d of %d", i, height)
             for j in range(0, width):
-                # Window is anchored at the current pixel (i, j) and extends
-                # down and to the right. Near the right and bottom edges the
-                # slice is clipped to the image, so those pixels use a
-                # truncated window instead of padding or being left unset.
-                window = self.nir_image[
-                    i : i + self.window_size, j : j + self.window_size
-                ]
-                glcm = graycomatrix(window, [1], [0], normed=True, symmetric=True)
-                res = graycoprops(glcm, self.property)[0][0]
-                self.result[i, j] = res
+                window = image[i : i + self.window_size, j : j + self.window_size]
+
+                glcm = graycomatrix(
+                    window,
+                    self.distances,
+                    self.angles,
+                    levels=self.levels,
+                    normed=True,
+                    symmetric=True,
+                )
+                # graycoprops returns (len(distances), len(angles)); averaging
+                # over both gives the rotation invariant scalar.
+                self.result[i, j] = graycoprops(glcm, self.property).mean()
+
         self._output = self.result
+        return self._output
 
     def _validate(self):
         if not isinstance(self.window_size, int) or isinstance(self.window_size, bool):
@@ -57,6 +174,24 @@ class GLCMCalculator(BaseTool):
             raise ValueError(
                 "window_size must be an odd integer greater than or equal to 3."
             )
+
+        if not isinstance(self.levels, int) or isinstance(self.levels, bool):
+            raise ValueError("levels must be an int.")
+        if self.levels < 2 or self.levels > 256:
+            raise ValueError("levels must be an int between 2 and 256.")
+
+        if len(self.distances) == 0:
+            raise ValueError("distances must contain at least one offset.")
+        if any(
+            not isinstance(distance, (int, np.integer))
+            or isinstance(distance, bool)
+            or distance < 1
+            for distance in self.distances
+        ):
+            raise ValueError("distances must be positive integers.")
+
+        if len(self.angles) == 0:
+            raise ValueError("angles must contain at least one orientation.")
 
         valid_properties = get_args(PropertyGLCMType)
         if self.property not in valid_properties:

--- a/tests/tools/glcm/glcm_calculator_test.py
+++ b/tests/tools/glcm/glcm_calculator_test.py
@@ -3,7 +3,13 @@ import pytest
 from unittest.mock import MagicMock, patch
 from skimage.feature import graycomatrix, graycoprops
 
-from fezrs.tools.glcm.glcm_calculator import GLCMCalculator
+from fezrs.tools.glcm.glcm_calculator import (
+    DEFAULT_ANGLES,
+    DEFAULT_DISTANCES,
+    DEFAULT_LEVELS,
+    GLCMCalculator,
+    quantize_to_levels,
+)
 
 
 @pytest.fixture
@@ -29,9 +35,13 @@ def calculator():
     }
 
     obj.result = np.empty((4, 4))
-    obj.nir_image = image
     obj.window_size = 3
     obj.property = "contrast"
+    obj.levels = DEFAULT_LEVELS
+    obj.distances = DEFAULT_DISTANCES
+    obj.angles = DEFAULT_ANGLES
+    obj.centered = True
+    obj.nir_image = quantize_to_levels(image, obj.levels)
     obj._output = None
 
     return obj
@@ -167,10 +177,37 @@ NONSQUARE_IMAGE = np.array(
 )
 
 
-def _expected_glcm_value(image, row, col, window_size, property_name):
-    window = image[row : row + window_size, col : col + window_size]
-    glcm = graycomatrix(window, [1], [0], normed=True, symmetric=True)
-    return graycoprops(glcm, property_name)[0][0]
+def _expected_glcm_value(
+    image,
+    row,
+    col,
+    window_size,
+    property_name,
+    levels=DEFAULT_LEVELS,
+    distances=DEFAULT_DISTANCES,
+    angles=DEFAULT_ANGLES,
+    centered=True,
+):
+    """
+    Reference value mirroring the calculator: quantize globally, optionally
+    reflect-pad so the window is centered, then average the property over every
+    distance/angle pair.
+    """
+    quantized = quantize_to_levels(image, levels)
+
+    if centered:
+        quantized = np.pad(quantized, window_size // 2, mode="reflect")
+
+    window = quantized[row : row + window_size, col : col + window_size]
+    glcm = graycomatrix(
+        window,
+        distances,
+        angles,
+        levels=levels,
+        normed=True,
+        symmetric=True,
+    )
+    return graycoprops(glcm, property_name).mean()
 
 
 @pytest.fixture
@@ -219,17 +256,13 @@ def test_nonsquare_output_shape(nonsquare_calculator):
 
 def test_nonsquare_interior_matches_skimage(nonsquare_calculator):
     """
-    Interior pixels have a full window and must match graycomatrix/graycoprops.
+    Interior pixels must match graycomatrix/graycoprops run over the same
+    quantized, centered window.
     """
     nonsquare_calculator.process()
 
-    interior_pixels = ((0, 0), (0, 2), (1, 4))
+    interior_pixels = ((1, 1), (1, 4), (2, 3))
     for row, col in interior_pixels:
-        window = NONSQUARE_IMAGE[
-            row : row + WINDOW_SIZE, col : col + WINDOW_SIZE
-        ]
-        assert window.shape == (WINDOW_SIZE, WINDOW_SIZE)
-
         expected = _expected_glcm_value(
             NONSQUARE_IMAGE, row, col, WINDOW_SIZE, "contrast"
         )
@@ -239,19 +272,23 @@ def test_nonsquare_interior_matches_skimage(nonsquare_calculator):
         )
 
 
-def test_nonsquare_top_left_uses_full_window(nonsquare_calculator):
+def test_centered_window_gives_every_pixel_a_full_neighbourhood(
+    nonsquare_calculator,
+):
     """
-    The window is anchored at (row, col) and extends down/right, so the
-    top and left borders still have a full window_size x window_size block.
+    Under the default centered window, reflect padding means border pixels get a
+    full window_size x window_size neighbourhood rather than a truncated one,
+    and every output pixel is finite.
     """
     nonsquare_calculator.process()
 
-    top_left_pixels = ((0, 0), (0, 3), (1, 0))
-    for row, col in top_left_pixels:
-        window = NONSQUARE_IMAGE[
-            row : row + WINDOW_SIZE, col : col + WINDOW_SIZE
-        ]
-        assert window.shape == (WINDOW_SIZE, WINDOW_SIZE)
+    border_pixels = (
+        (0, 0),
+        (0, WIDTH - 1),
+        (HEIGHT - 1, 0),
+        (HEIGHT - 1, WIDTH - 1),
+    )
+    for row, col in border_pixels:
         expected = _expected_glcm_value(
             NONSQUARE_IMAGE, row, col, WINDOW_SIZE, "contrast"
         )
@@ -260,12 +297,52 @@ def test_nonsquare_top_left_uses_full_window(nonsquare_calculator):
             expected,
         )
 
+    assert np.isfinite(nonsquare_calculator._output).all()
 
-def test_nonsquare_border_uses_truncated_window(nonsquare_calculator):
+
+def test_centered_window_is_not_offset_from_the_source_grid():
     """
-    Near the right and bottom edges the window is clipped to the image.
-    Those pixels are still computed, not left uninitialized.
+    A centered window puts the texture response of a feature on the feature's
+    own pixel. With the legacy anchored window the same response lands
+    (window_size - 1) // 2 pixels up and to the left, which offsets the whole
+    texture map relative to the source raster.
     """
+    image = np.zeros((9, 9), dtype=np.uint8)
+    image[4, 4] = 200  # single bright pixel at the exact centre
+
+    def build(centered):
+        obj = GLCMCalculator.__new__(GLCMCalculator)
+        obj.metadata_bands = {
+            "nir": {"width": 9, "height": 9, "image_skimage": image}
+        }
+        obj.result = np.empty((9, 9))
+        obj.window_size = 3
+        obj.property = "contrast"
+        obj.levels = DEFAULT_LEVELS
+        obj.distances = DEFAULT_DISTANCES
+        obj.angles = DEFAULT_ANGLES
+        obj.centered = centered
+        obj.nir_image = quantize_to_levels(image, obj.levels)
+        obj._output = None
+        obj.process()
+        return obj._output
+
+    centered = build(True)
+    anchored = build(False)
+
+    # The strongest contrast sits on the bright pixel itself when centered...
+    assert np.unravel_index(np.argmax(centered), centered.shape) == (4, 4)
+    # ...and is displaced up/left by one pixel under the legacy anchoring.
+    assert np.unravel_index(np.argmax(anchored), anchored.shape) == (3, 3)
+
+
+def test_legacy_anchored_window_still_available(nonsquare_calculator):
+    """
+    centered=False preserves the previous behaviour: the window is anchored at
+    (row, col), extends down and to the right, and is clipped at the right and
+    bottom edges.
+    """
+    nonsquare_calculator.centered = False
     nonsquare_calculator.process()
 
     border_pixels = (
@@ -281,7 +358,12 @@ def test_nonsquare_border_uses_truncated_window(nonsquare_calculator):
         assert window.shape[0] < WINDOW_SIZE or window.shape[1] < WINDOW_SIZE
 
         expected = _expected_glcm_value(
-            NONSQUARE_IMAGE, row, col, WINDOW_SIZE, "contrast"
+            NONSQUARE_IMAGE,
+            row,
+            col,
+            WINDOW_SIZE,
+            "contrast",
+            centered=False,
         )
         np.testing.assert_allclose(
             nonsquare_calculator._output[row, col],
@@ -297,3 +379,190 @@ def test_nonsquare_border_uses_truncated_window(nonsquare_calculator):
 #     calculator = GLCMCalculator(
 #         nir_path=nir_path, window_size=3, propery="ASM"
 #     ).execute(output_path="./", title="GLCM output")
+
+
+# --- Quantization (issue #38) -------------------------------------------------
+
+
+def test_quantization_preserves_gray_level_ordering():
+    """
+    The previous np.array(..., dtype="uint8") wrapped modulo 256, so DN 3311
+    became 239 and DN 6200 became 56 -- radiometrically adjacent pixels landed at
+    opposite ends of the gray-level range. Quantization must be monotonic.
+    """
+    values = np.array([[23, 255, 256, 3311, 6200]], dtype=np.int16)
+
+    quantized = quantize_to_levels(values, DEFAULT_LEVELS)
+
+    assert np.all(np.diff(quantized[0]) >= 0)
+    assert np.corrcoef(values.ravel(), quantized.ravel())[0, 1] > 0.99
+
+
+def test_quantization_of_16bit_raster_is_not_a_wraparound_cast():
+    rng = np.random.default_rng(0)
+    band = rng.integers(23, 6200, size=(64, 64)).astype(np.int16)
+
+    wrapped = np.array(band, dtype="uint8")
+    quantized = quantize_to_levels(band, DEFAULT_LEVELS)
+
+    assert np.corrcoef(band.ravel(), wrapped.ravel())[0, 1] < 0.5
+    assert np.corrcoef(band.ravel(), quantized.ravel())[0, 1] > 0.99
+
+
+def test_quantization_respects_levels():
+    band = np.arange(0, 10000, dtype=np.int32).reshape(100, 100)
+
+    for levels in (2, 16, 32, 64, 256):
+        quantized = quantize_to_levels(band, levels)
+        assert quantized.min() == 0
+        assert quantized.max() == levels - 1
+
+
+def test_quantization_of_constant_band_is_all_zero():
+    band = np.full((8, 8), 4200, dtype=np.int16)
+
+    quantized = quantize_to_levels(band, DEFAULT_LEVELS)
+
+    assert quantized.dtype == np.uint8
+    assert np.all(quantized == 0)
+
+
+def test_quantization_is_global_not_per_window():
+    """
+    Two windows with the same local spread but different absolute levels must
+    quantize differently, otherwise texture values are not comparable across the
+    scene.
+    """
+    band = np.zeros((4, 8), dtype=np.int16)
+    band[:, :4] = np.tile(np.array([100, 110], dtype=np.int16), (4, 2))
+    band[:, 4:] = np.tile(np.array([5000, 5010], dtype=np.int16), (4, 2))
+
+    quantized = quantize_to_levels(band, DEFAULT_LEVELS)
+
+    assert quantized[:, :4].max() < quantized[:, 4:].min()
+
+
+def test_validate_rejects_out_of_range_levels(calculator):
+    for levels in (1, 0, -4, 257):
+        calculator.levels = levels
+        with pytest.raises(ValueError, match="levels"):
+            calculator._validate()
+
+
+def test_validate_rejects_non_integer_levels(calculator):
+    calculator.levels = 64.0
+    with pytest.raises(ValueError, match="levels must be an int"):
+        calculator._validate()
+
+
+# --- Orientation (issue #38) --------------------------------------------------
+
+
+def test_angle_averaged_texture_is_rotation_invariant():
+    """
+    A striped pattern and its 90-degree rotation must yield the same texture
+    under the default angle-averaged form.
+    """
+    stripes = np.tile(np.array([[0], [200]], dtype=np.uint8), (4, 8))
+    rotated = np.rot90(stripes)
+
+    def texture(image, angles):
+        obj = GLCMCalculator.__new__(GLCMCalculator)
+        height, width = image.shape
+        obj.metadata_bands = {
+            "nir": {"width": width, "height": height, "image_skimage": image}
+        }
+        obj.result = np.empty((height, width))
+        obj.window_size = 3
+        obj.property = "contrast"
+        obj.levels = DEFAULT_LEVELS
+        obj.distances = DEFAULT_DISTANCES
+        obj.angles = angles
+        obj.centered = True
+        obj.nir_image = quantize_to_levels(image, obj.levels)
+        obj._output = None
+        obj.process()
+        return float(np.mean(obj._output))
+
+    averaged = (texture(stripes, DEFAULT_ANGLES), texture(rotated, DEFAULT_ANGLES))
+    single = (texture(stripes, (0.0,)), texture(rotated, (0.0,)))
+
+    assert averaged[0] == pytest.approx(averaged[1])
+    # A single east-west orientation is direction dependent by construction.
+    assert single[0] != pytest.approx(single[1])
+
+
+def test_validate_rejects_empty_angles_and_distances(calculator):
+    calculator.angles = ()
+    with pytest.raises(ValueError, match="angles"):
+        calculator._validate()
+
+    calculator.angles = DEFAULT_ANGLES
+    calculator.distances = ()
+    with pytest.raises(ValueError, match="distances"):
+        calculator._validate()
+
+
+def test_validate_rejects_non_positive_distances(calculator):
+    calculator.distances = (0,)
+    with pytest.raises(ValueError, match="distances"):
+        calculator._validate()
+
+
+# --- Property spelling (issue #38 / #32) --------------------------------------
+
+
+def _fake_base_init(self, *args, **kwargs):
+    """Stand in for BaseTool.__init__ so no file is touched."""
+    handler = MagicMock()
+    handler.get_metadata_bands.return_value = {
+        "nir": {
+            "width": 4,
+            "height": 4,
+            "image_skimage": np.zeros((4, 4), dtype=np.uint8),
+        }
+    }
+    self.files_handler = handler
+    self._output = None
+
+
+def test_property_keyword_is_accepted():
+    with patch("fezrs.tools.glcm.glcm_calculator.BaseTool.__init__", _fake_base_init):
+        calculator = GLCMCalculator(nir_path="dummy.tif", property="energy")
+
+    assert calculator.property == "energy"
+
+
+def test_deprecated_propery_keyword_still_works():
+    with patch("fezrs.tools.glcm.glcm_calculator.BaseTool.__init__", _fake_base_init):
+        calculator = GLCMCalculator(nir_path="dummy.tif", propery="energy")
+
+    assert calculator.property == "energy"
+
+
+def test_passing_both_property_spellings_raises():
+    with patch("fezrs.tools.glcm.glcm_calculator.BaseTool.__init__", _fake_base_init):
+        with pytest.raises(ValueError, match="not both"):
+            GLCMCalculator(
+                nir_path="dummy.tif", propery="energy", property="contrast"
+            )
+
+
+def test_property_defaults_to_contrast():
+    with patch("fezrs.tools.glcm.glcm_calculator.BaseTool.__init__", _fake_base_init):
+        calculator = GLCMCalculator(nir_path="dummy.tif")
+
+    assert calculator.property == "contrast"
+
+
+# --- Logging (issue #38) ------------------------------------------------------
+
+
+def test_process_writes_nothing_to_stdout(calculator, capsys):
+    """
+    The per-row print wrote one line per raster row -- 998 lines for the bundled
+    example, with no way to disable it.
+    """
+    calculator.process()
+
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Problem

`GLCMCalculator.__init__` converted the input band with:

```python
self.nir_image = np.array(self.metadata_bands["nir"]["image_skimage"], dtype="uint8")
```

`np.array(..., dtype="uint8")` on integer input performs a **modular wraparound**, not a rescale and not a clip. Any value above 255 wraps modulo 256, so gray-level ordering is destroyed rather than compressed. This affects every 16-bit raster — Landsat, Sentinel, ASTER — including the repository's own example data.

Measured on `example/data/nir.tif` (int16, range 23–6200):

```
DN 3311 -> 239
DN 6200 ->  56
correlation between source band and the array fed to graycomatrix: -0.2248
```

Two radiometrically adjacent pixels (DN 255 and 256) land at opposite ends of the gray-level range. Every texture value the tool produced on 16-bit input was computed on effectively scrambled data.

## Changes

**1. Explicit global quantization.** Linear rescale to `levels` gray levels, monotonic, so ordering is preserved — correlation with the source band rises from −0.22 to 0.9995 on the same raster. Scaling uses whole-image extrema, not per-window: a texture value in one part of the scene must be comparable with one elsewhere, since in lithological discrimination the signal is the texture *contrast between units*. Constant bands map to zeros; non-finite pixels are excluded from the range.

**2. `levels` defaults to 64, not 256.** A `W×W` window supplies only `(W-1)·W·2` ordered pairs — 12 for `W=3`. Spreading 12 pairs over a 256×256 matrix populates 0.018% of its cells, so `contrast` and `correlation` end up describing matrix sparsity rather than surface texture. 32–64 levels is the standard working range for windowed GLCM.

**3. `distances` and `angles` exposed, results averaged over every pair.** The previous hardcoded `[1], [0]` measured texture only east–west, so a surface-roughness map depended on how the scene happened to be oriented. The four-angle default is rotation invariant. A single angle remains available, which is what you want for deliberately directional targets — bedding traces, foliation, dune crests, lineament fabric.

**4. Window centered on its pixel by default**, with reflect padding. The window was anchored at `(i, j)` and extended down and to the right, displacing the entire texture map by `(W-1)//2` pixels relative to the source grid. At 30 m Landsat resolution with `W=15` that is a **210 m offset** — a georeferencing error the moment the result is overlaid on a geological map or exported as a georeferenced raster. Reflect padding also means border pixels get a full neighbourhood instead of a truncated one. `centered=False` restores the previous behaviour.

**5. Smaller items from the issue:** `property` accepted as the correct spelling with `propery` still working (the #32 fix had not landed on `main`); the per-row `print` replaced with a module `logging` call at DEBUG level.

## Behaviour changes

Deliberate, and documented in `docs/glcm.md`:

- Texture values change for **all** inputs, not only 16-bit ones — quantization now always rescales, and the default is 64 levels with four averaged angles.
- Output is registered half a window differently, since the window is now centered.
- Runtime scales with `len(distances) × len(angles)`, so the default is ~4× the previous cost. Noted in the docs.

The public constructor signature is unchanged for existing positional and keyword calls; every new parameter is keyword-only with a default.

## Documentation

`docs/glcm.md` described the cast as "Quantization Baseline" and the window offset as intended behaviour, and its formulation section assumed input already lay in `[0, G-1]` with nothing enforcing it. All three are corrected, with the reasoning for the `levels` default and the registration consequence of `centered=False` written out.

## Tests

322 pass (306 before, 16 new). New coverage:

- Quantization is monotonic and preserves gray-level ordering on values > 255; correlation with a synthetic 16-bit band > 0.99 where the wraparound cast gives < 0.5.
- `levels` honored across 2–256; constant band maps to zeros; quantization is global rather than per-window.
- Angle-averaged texture is rotation invariant on a striped pattern and its 90° rotation, while single-angle texture is not.
- A single bright pixel produces peak contrast on its own pixel when centered, and displaced by one pixel under the legacy anchoring — the registration fix, asserted directly.
- Both property spellings accepted, passing both raises, validation of `levels`/`distances`/`angles`.
- `process()` writes nothing to stdout.

The existing `_expected_glcm_value` reference helper was updated to mirror the corrected pipeline, and the border-behaviour tests were split into a centered case and a `centered=False` legacy case.

Verified end-to-end on a 64×64 crop of `example/data/nir.tif`: finite output, quantization correlation 0.9995, silent stdout.
