### PR TITLE
FIX spectral indices to use band values as read, with radiometric scaling

### DIFF
--- a/docs/spectral-indices.md
+++ b/docs/spectral-indices.md
@@ -17,7 +17,7 @@ By calculating normalized differences, empirical scaling offsets, and non-linear
                                     │
                                     ▼
                     ┌────────────────────────────────┐
-                    │ Linear Quantization Scaling    │ ──► $I_{\text{norm}} \in [0.0, 1.0]$
+                    │ Radiometric Scaling (optional) │ ──► $\rho = \text{DN} \times s + o$
                     └───────────────┬────────────────┘
                                     │
          ┌──────────────────────────┴──────────────────────────┐
@@ -33,6 +33,48 @@ By calculating normalized differences, empirical scaling offsets, and non-linear
                     │    Dimensionless Float Output  │ ──► Dynamic range: $[-1.0, 1.0]$ or $[0.0, 1.0]$
                     └────────────────────────────────┘
 ```
+
+## Radiometric Input Requirements
+
+**Indices are computed on the band values as read.** No rescaling is applied unless you ask for it.
+
+> **Changed in 1.4.0.** Earlier releases routed every index through a per-band min–max rescale, $(x - x_{\min}) / (x_{\max} - x_{\min})$, applied *independently to each band*. Because each band received a different affine transform, this altered the relationships **between** bands — and those relationships are the entire physical content of a spectral index. Three consequences: published thresholds did not apply, values were not comparable across scenes or dates, and **a pixel's value depended on how much of the image you loaded**, since the rescale used the loaded extent's own extrema. Index values from earlier versions are not comparable with current output.
+>
+> Measured on the bundled example, the rescale inverted inter-band relationships outright: AFRI's correlation with NDVI ran **+0.71 on the values as stored and −0.69 after rescaling**, against a source paper that reports the two as nearly identical. Min–max normalization remains in use for the enhancement, HSV, PCA and SVM modules, where rescaling is appropriate — and for SVM it is necessary, since an RBF kernel needs comparable feature scales.
+
+### Which indices need reflectance, and which do not
+
+| Index | Constant in reflectance units? | Safe on raw DN? |
+|---|---|---|
+| NDVI, NDWI, UI, BSI | none | **Yes** — a normalized difference is invariant to a gain applied to all bands equally |
+| SAVI | soil adjustment $L = 0.5$ | **No** |
+| AFRI | coefficients $0.66$ / $0.50$ on SWIR | **No** |
+
+Adding $L = 0.5$ to a digital number in the thousands contributes nothing, so SAVI on unscaled input is silently not SAVI. The same applies to AFRI's coefficients. Both emit a `UserWarning` when handed values far outside the reflectance range.
+
+### Supplying the scaling
+
+Every index accepts `scale_factor` and `offset`, applied as $\rho = \text{DN} \times s + o$. Published values for the common analysis-ready products ship as `RADIOMETRIC_PRESETS`:
+
+```Python
+from fezrs import SAVICalculator
+from fezrs.utils.radiometry_handler import RADIOMETRIC_PRESETS
+
+SAVICalculator(
+    nir_path="LC09_..._SR_B5.TIF",
+    red_path="LC09_..._SR_B4.TIF",
+    **RADIOMETRIC_PRESETS["landsat-c2-l2"],       # scale 2.75e-5, offset -0.2
+).execute(output_path="./exports/")
+```
+
+| Preset | Scale | Offset |
+|---|---|---|
+| `landsat-c2-l2` | $2.75 \times 10^{-5}$ | $-0.2$ |
+| `sentinel2-l2a` | $10^{-4}$ | $0.0$ |
+| `sentinel2-l2a-baseline4` | $10^{-4}$ | $-0.1$ |
+| `reflectance` | $1.0$ | $0.0$ |
+
+Sentinel-2 processing baseline 04.00 and later carries a `BOA_ADD_OFFSET` of $-1000$, hence the separate preset. If your product is already reflectance, the defaults are correct and nothing needs passing.
 
 ## Mathematical & Scientific Formulations
 

--- a/fezrs/tools/spectral_indices/afri_calculator.py
+++ b/fezrs/tools/spectral_indices/afri_calculator.py
@@ -1,6 +1,7 @@
 # Import module and files
 from fezrs.base import BaseTool
 from fezrs.tools.spectral_indices._division import divide_with_nan
+from fezrs.utils.radiometry_handler import apply_scaling, warn_if_not_reflectance
 from fezrs.utils.type_handler import AFRIVariantType, BandPathType
 
 
@@ -38,6 +39,8 @@ class AFRICalculator(BaseTool):
         swir1_path: BandPathType | None = None,
         swir2_path: BandPathType | None = None,
         variant: AFRIVariantType = "1.6",
+        scale_factor: float = 1.0,
+        offset: float = 0.0,
     ):
         """
         Args:
@@ -45,6 +48,8 @@ class AFRICalculator(BaseTool):
             swir1_path: SWIR ~1.6 um band, required for the ``"1.6"`` variant.
             swir2_path: SWIR ~2.1 um band, required for the ``"2.1"`` variant.
             variant: Which AFRI formulation to compute.
+            scale_factor: Multiplicative radiometric scale, see RADIOMETRIC_PRESETS.
+            offset: Additive radiometric offset.
         """
         if variant not in AFRI_COEFFICIENTS:
             raise ValueError(
@@ -71,16 +76,19 @@ class AFRICalculator(BaseTool):
 
         super().__init__(**band_paths)
 
-        self.normalized_bands = self.files_handler.get_normalized_bands(
-            requested_bands=["nir", self.swir_band]
+        self.source_bands = apply_scaling(
+            self.files_handler.get_bands(requested_bands=["nir", self.swir_band]),
+            scale_factor=scale_factor,
+            offset=offset,
         )
+        warn_if_not_reflectance(self.source_bands, "AFRI")
 
     def _validate(self):
         pass
 
     def process(self):
         nir, swir = (
-            self.normalized_bands[band] for band in ("nir", self.swir_band)
+            self.source_bands[band] for band in ("nir", self.swir_band)
         )
 
         self._output = divide_with_nan(

--- a/fezrs/tools/spectral_indices/bi_calculator.py
+++ b/fezrs/tools/spectral_indices/bi_calculator.py
@@ -3,6 +3,7 @@ import warnings
 # Import module and files
 from fezrs.base import BaseTool
 from fezrs.tools.spectral_indices._division import divide_with_nan
+from fezrs.utils.radiometry_handler import apply_scaling
 from fezrs.utils.type_handler import BandPathType, BIFormulationType
 
 
@@ -40,6 +41,8 @@ class BICalculator(BaseTool):
         swir1_path: BandPathType | None = None,
         blue_path: BandPathType | None = None,
         formulation: BIFormulationType | None = None,
+        scale_factor: float = 1.0,
+        offset: float = 0.0,
     ):
         """
         Args:
@@ -50,6 +53,8 @@ class BICalculator(BaseTool):
             blue_path: Blue band, required by ``"bsi"``.
             formulation: ``"bsi"`` or ``"legacy"``. Inferred from the supplied
                 bands when omitted.
+            scale_factor: Multiplicative radiometric scale, see RADIOMETRIC_PRESETS.
+            offset: Additive radiometric offset.
         """
         if formulation is None:
             formulation = (
@@ -95,8 +100,10 @@ class BICalculator(BaseTool):
 
         super().__init__(**band_paths)
 
-        self.normalized_bands = self.files_handler.get_normalized_bands(
-            requested_bands=list(self._required_bands)
+        self.source_bands = apply_scaling(
+            self.files_handler.get_bands(requested_bands=list(self._required_bands)),
+            scale_factor=scale_factor,
+            offset=offset,
         )
 
     def _validate(self):
@@ -105,7 +112,7 @@ class BICalculator(BaseTool):
     def process(self):
         if self.formulation == "bsi":
             swir1, red, nir, blue = (
-                self.normalized_bands[band]
+                self.source_bands[band]
                 for band in ("swir1", "red", "nir", "blue")
             )
             self._output = divide_with_nan(
@@ -114,7 +121,7 @@ class BICalculator(BaseTool):
             )
         else:
             nir, red, green = (
-                self.normalized_bands[band] for band in ("nir", "red", "green")
+                self.source_bands[band] for band in ("nir", "red", "green")
             )
             self._output = divide_with_nan(
                 (nir - green) - red,

--- a/fezrs/tools/spectral_indices/ndvi_calculator.py
+++ b/fezrs/tools/spectral_indices/ndvi_calculator.py
@@ -4,6 +4,7 @@ from matplotlib.pyplot import cm
 # Import module and files
 from fezrs.base import BaseTool
 from fezrs.tools.spectral_indices._division import divide_with_nan
+from fezrs.utils.radiometry_handler import apply_scaling, warn_if_not_reflectance
 from fezrs.utils.type_handler import BandPathType
 
 
@@ -13,17 +14,22 @@ class NDVICalculator(BaseTool):
         self,
         nir_path: BandPathType,
         red_path: BandPathType,
+        scale_factor: float = 1.0,
+        offset: float = 0.0,
     ):
         super().__init__(nir_path=nir_path, red_path=red_path)
-        self.normalized_bands = self.files_handler.get_normalized_bands(
-            requested_bands=["nir", "red"]
+        self.source_bands = apply_scaling(
+            self.files_handler.get_bands(requested_bands=["nir", "red"]),
+            scale_factor=scale_factor,
+            offset=offset,
         )
+        warn_if_not_reflectance(self.source_bands, "NDVI")
 
     def _validate(self):
         pass
 
     def process(self):
-        nir, red = (self.normalized_bands[band] for band in ("nir", "red"))
+        nir, red = (self.source_bands[band] for band in ("nir", "red"))
 
         self._output = divide_with_nan(nir - red, nir + red)
         return self._output

--- a/fezrs/tools/spectral_indices/ndwi_calculator.py
+++ b/fezrs/tools/spectral_indices/ndwi_calculator.py
@@ -4,6 +4,7 @@ from matplotlib.pyplot import cm
 # Import module and files
 from fezrs.base import BaseTool
 from fezrs.tools.spectral_indices._division import divide_with_nan
+from fezrs.utils.radiometry_handler import apply_scaling, warn_if_not_reflectance
 from fezrs.utils.type_handler import BandPathType
 
 
@@ -13,17 +14,22 @@ class NDWICalculator(BaseTool):
         self,
         nir_path: BandPathType,
         green_path: BandPathType,
+        scale_factor: float = 1.0,
+        offset: float = 0.0,
     ):
         super().__init__(nir_path=nir_path, green_path=green_path)
-        self.normalized_bands = self.files_handler.get_normalized_bands(
-            requested_bands=["nir", "green"]
+        self.source_bands = apply_scaling(
+            self.files_handler.get_bands(requested_bands=["nir", "green"]),
+            scale_factor=scale_factor,
+            offset=offset,
         )
+        warn_if_not_reflectance(self.source_bands, "NDWI")
 
     def _validate(self):
         pass
 
     def process(self):
-        nir, green = (self.normalized_bands[band] for band in ("nir", "green"))
+        nir, green = (self.source_bands[band] for band in ("nir", "green"))
 
         self._output = divide_with_nan(green - nir, nir + green)
         return self._output

--- a/fezrs/tools/spectral_indices/savi_calculator.py
+++ b/fezrs/tools/spectral_indices/savi_calculator.py
@@ -1,6 +1,7 @@
 # Import module and files
 from fezrs.base import BaseTool
 from fezrs.tools.spectral_indices._division import divide_with_nan
+from fezrs.utils.radiometry_handler import apply_scaling, warn_if_not_reflectance
 from fezrs.utils.type_handler import BandPathType
 
 
@@ -10,17 +11,22 @@ class SAVICalculator(BaseTool):
         self,
         nir_path: BandPathType,
         red_path: BandPathType,
+        scale_factor: float = 1.0,
+        offset: float = 0.0,
     ):
         super().__init__(nir_path=nir_path, red_path=red_path)
-        self.normalized_bands = self.files_handler.get_normalized_bands(
-            requested_bands=["nir", "red"]
+        self.source_bands = apply_scaling(
+            self.files_handler.get_bands(requested_bands=["nir", "red"]),
+            scale_factor=scale_factor,
+            offset=offset,
         )
+        warn_if_not_reflectance(self.source_bands, "SAVI")
 
     def _validate(self):
         pass
 
     def process(self):
-        nir, red = (self.normalized_bands[band] for band in ("nir", "red"))
+        nir, red = (self.source_bands[band] for band in ("nir", "red"))
 
         self._output = divide_with_nan(nir - red, nir + red + 0.5) * 1.5
         return self._output

--- a/fezrs/tools/spectral_indices/ui_calculator.py
+++ b/fezrs/tools/spectral_indices/ui_calculator.py
@@ -4,6 +4,7 @@ from matplotlib.pyplot import cm
 # Import module and files
 from fezrs.base import BaseTool
 from fezrs.tools.spectral_indices._division import divide_with_nan
+from fezrs.utils.radiometry_handler import apply_scaling, warn_if_not_reflectance
 from fezrs.utils.type_handler import BandPathType
 
 
@@ -13,17 +14,22 @@ class UICalculator(BaseTool):
         self,
         nir_path: BandPathType,
         swir2_path: BandPathType,
+        scale_factor: float = 1.0,
+        offset: float = 0.0,
     ):
         super().__init__(nir_path=nir_path, swir2_path=swir2_path)
-        self.normalized_bands = self.files_handler.get_normalized_bands(
-            requested_bands=["nir", "swir2"]
+        self.source_bands = apply_scaling(
+            self.files_handler.get_bands(requested_bands=["nir", "swir2"]),
+            scale_factor=scale_factor,
+            offset=offset,
         )
+        warn_if_not_reflectance(self.source_bands, "UI")
 
     def _validate(self):
         pass
 
     def process(self):
-        nir, swir2 = (self.normalized_bands[band] for band in ("nir", "swir2"))
+        nir, swir2 = (self.source_bands[band] for band in ("nir", "swir2"))
 
         self._output = divide_with_nan(swir2 - nir, nir + swir2)
         return self._output

--- a/fezrs/utils/__init__.py
+++ b/fezrs/utils/__init__.py
@@ -1,3 +1,4 @@
 from .file_handler import *
+from .radiometry_handler import *
 from .type_handler import *
 from .histogram_handler import *

--- a/fezrs/utils/file_handler.py
+++ b/fezrs/utils/file_handler.py
@@ -198,6 +198,33 @@ class FileHandler:
             if self.bands.get(band) is not None
         }
 
+    def get_bands(self, requested_bands: Optional[List[BandNameType]] = None):
+        """
+        Retrieve the requested image bands with their values as read.
+
+        Unlike :meth:`get_normalized_bands`, no rescaling is applied. Spectral
+        indices must use this accessor: a per-band min-max rescale gives each
+        band a different affine transform, which alters the relationships
+        *between* bands, and those relationships are the entire physical content
+        of a band ratio.
+
+        Args:
+            requested_bands (Optional[List[BandNameType]]): A list of band names
+                to return. If None, all available bands are returned.
+
+        Returns:
+            Dict[str, Optional[np.ndarray]]: A dictionary mapping band names to
+                their image data as read. Bands with no data are excluded.
+        """
+        if requested_bands is None:
+            requested_bands = list(self.bands.keys())
+
+        return {
+            band: self.bands[band]
+            for band in requested_bands
+            if self.bands.get(band) is not None
+        }
+
     def get_metadata_bands(
         self, requested_bands: Optional[list[BandNameType]] = None
     ) -> Dict[str, Dict]:

--- a/fezrs/utils/radiometry_handler.py
+++ b/fezrs/utils/radiometry_handler.py
@@ -1,0 +1,102 @@
+"""
+Radiometric scaling for spectral indices.
+
+Satellite products are distributed as scaled integers, not as reflectance. A
+spectral index built from ratios of *the same* linear scale is insensitive to a
+common gain, but two classes of index are not:
+
+* indices carrying an **additive constant** in reflectance units, such as SAVI's
+  soil adjustment ``L = 0.5``;
+* indices carrying a **band-specific coefficient**, such as AFRI's 0.66 and 0.50.
+
+For those the input must actually be reflectance, otherwise the constant is
+being added to a digital number in the thousands and contributes nothing. This
+module converts a product's stored integers to reflectance:
+
+    rho = DN * scale_factor + offset
+"""
+
+import warnings
+
+import numpy as np
+
+
+# Published scaling for the common analysis-ready products. Splat one into a
+# calculator: NDVICalculator(..., **RADIOMETRIC_PRESETS["landsat-c2-l2"]).
+RADIOMETRIC_PRESETS = {
+    # Landsat Collection 2 Level-2 surface reflectance.
+    "landsat-c2-l2": {"scale_factor": 2.75e-5, "offset": -0.2},
+    # Sentinel-2 L2A, processing baseline < 04.00.
+    "sentinel2-l2a": {"scale_factor": 1e-4, "offset": 0.0},
+    # Sentinel-2 L2A, processing baseline >= 04.00 carries BOA_ADD_OFFSET.
+    "sentinel2-l2a-baseline4": {"scale_factor": 1e-4, "offset": -0.1},
+    # Input already expressed as reflectance.
+    "reflectance": {"scale_factor": 1.0, "offset": 0.0},
+}
+
+# Physically plausible reflectance bounds, with headroom for specular returns
+# and for the slight out-of-range values common in atmospherically corrected
+# products.
+_REFLECTANCE_CEILING = 1.5
+
+# Indices whose constants are defined in reflectance units, so feeding them
+# unscaled digital numbers silently produces a meaningless result.
+_REFLECTANCE_DEPENDENT = ("SAVI", "AFRI")
+
+
+def apply_scaling(bands, scale_factor=1.0, offset=0.0):
+    """
+    Convert stored band values to reflectance.
+
+    Args:
+        bands: Mapping of band name to array.
+        scale_factor: Multiplicative scale from the product specification.
+        offset: Additive offset from the product specification.
+
+    Returns:
+        dict: Mapping of band name to scaled array. Returned unchanged when the
+            scaling is the identity, so the common case allocates nothing.
+    """
+    if scale_factor == 1.0 and offset == 0.0:
+        return dict(bands)
+
+    return {
+        name: None if array is None else np.asarray(array, dtype=float) * scale_factor
+        + offset
+        for name, array in bands.items()
+    }
+
+
+def warn_if_not_reflectance(bands, index_name):
+    """
+    Warn when a reflectance-dependent index is handed unscaled data.
+
+    Args:
+        bands: Mapping of band name to array.
+        index_name: Index label, used to decide whether the check applies and to
+            build the message.
+    """
+    if index_name not in _REFLECTANCE_DEPENDENT:
+        return
+
+    for name, array in bands.items():
+        if array is None:
+            continue
+
+        finite = np.asarray(array)[np.isfinite(array)]
+        if finite.size == 0:
+            continue
+
+        peak = float(np.max(np.abs(finite)))
+        if peak > _REFLECTANCE_CEILING:
+            warnings.warn(
+                f"{index_name} band {name!r} reaches {peak:.1f}, which is far "
+                "outside the reflectance range [0, 1]. This index carries "
+                "constants defined in reflectance units, so unscaled digital "
+                "numbers produce a value with no physical meaning. Pass "
+                "scale_factor/offset for your product, e.g. "
+                "**RADIOMETRIC_PRESETS['landsat-c2-l2'].",
+                UserWarning,
+                stacklevel=3,
+            )
+            return

--- a/tests/tools/spectral_indices/afri_calculator_test.py
+++ b/tests/tools/spectral_indices/afri_calculator_test.py
@@ -9,18 +9,18 @@ from fezrs.tools.spectral_indices.afri_calculator import AFRICalculator
 
 @pytest.fixture
 def mock_afri_calculator():
-    fake_normalized_bands = {
+    fake_source_bands = {
         "nir": np.random.rand(100, 100),
         "swir1": np.random.rand(100, 100),
     }
 
     fake_files_handler = MagicMock()
-    fake_files_handler.get_normalized_bands.return_value = fake_normalized_bands
+    fake_files_handler.get_bands.return_value = fake_source_bands
 
     def fake_init(self, *args, **kwargs):
         self.files_handler = fake_files_handler
         self._output = None
-        self.normalized_bands = fake_normalized_bands
+        self.source_bands = fake_source_bands
 
     with patch(
         "fezrs.tools.spectral_indices.afri_calculator.BaseTool.__init__",
@@ -35,9 +35,9 @@ def mock_afri_calculator():
 
 
 def test_initialization(mock_afri_calculator):
-    assert mock_afri_calculator.normalized_bands is not None
-    assert "nir" in mock_afri_calculator.normalized_bands
-    assert "swir1" in mock_afri_calculator.normalized_bands
+    assert mock_afri_calculator.source_bands is not None
+    assert "nir" in mock_afri_calculator.source_bands
+    assert "swir1" in mock_afri_calculator.source_bands
     assert mock_afri_calculator._output is None
 
 
@@ -52,13 +52,13 @@ def test_process_calculates_afri_correctly(mock_afri_calculator):
     The 0.66 coefficient multiplies the SWIR reflectance; it is not subtracted
     from NIR as a bare constant.
     """
-    mock_afri_calculator.normalized_bands = {
+    mock_afri_calculator.source_bands = {
         "nir": np.array([[0.5, 0.6], [0.7, 0.8]]),
         "swir1": np.array([[0.1, 0.2], [0.3, 0.4]]),
     }
 
-    nir = mock_afri_calculator.normalized_bands["nir"]
-    swir1 = mock_afri_calculator.normalized_bands["swir1"]
+    nir = mock_afri_calculator.source_bands["nir"]
+    swir1 = mock_afri_calculator.source_bands["swir1"]
     expected = (nir - 0.66 * swir1) / (nir + 0.66 * swir1)
 
     result = mock_afri_calculator.process()
@@ -68,7 +68,7 @@ def test_process_calculates_afri_correctly(mock_afri_calculator):
 
 
 def test_process_handles_zero_division(mock_afri_calculator):
-    mock_afri_calculator.normalized_bands = {
+    mock_afri_calculator.source_bands = {
         "nir": np.zeros((100, 100)),
         "swir1": np.zeros((100, 100)),
     }
@@ -85,7 +85,7 @@ def test_process_handles_zero_division(mock_afri_calculator):
 
 
 def test_process_returns_correct_shape(mock_afri_calculator):
-    mock_afri_calculator.normalized_bands = {
+    mock_afri_calculator.source_bands = {
         "nir": np.random.rand(150, 200),
         "swir1": np.random.rand(150, 200),
     }

--- a/tests/tools/spectral_indices/bi_calculator_test.py
+++ b/tests/tools/spectral_indices/bi_calculator_test.py
@@ -9,19 +9,19 @@ from fezrs.tools.spectral_indices.bi_calculator import BICalculator
 
 @pytest.fixture
 def mock_bi_calculator():
-    fake_normalized_bands = {
+    fake_source_bands = {
         "nir": np.random.rand(100, 100),
         "red": np.random.rand(100, 100),
         "green": np.random.rand(100, 100),
     }
 
     fake_files_handler = MagicMock()
-    fake_files_handler.get_normalized_bands.return_value = fake_normalized_bands
+    fake_files_handler.get_bands.return_value = fake_source_bands
 
     def fake_init(self, *args, **kwargs):
         self.files_handler = fake_files_handler
         self._output = None
-        self.normalized_bands = fake_normalized_bands
+        self.source_bands = fake_source_bands
 
     with patch(
         "fezrs.tools.spectral_indices.bi_calculator.BaseTool.__init__",
@@ -37,10 +37,10 @@ def mock_bi_calculator():
 
 
 def test_initialization(mock_bi_calculator):
-    assert mock_bi_calculator.normalized_bands is not None
-    assert "nir" in mock_bi_calculator.normalized_bands
-    assert "red" in mock_bi_calculator.normalized_bands
-    assert "green" in mock_bi_calculator.normalized_bands
+    assert mock_bi_calculator.source_bands is not None
+    assert "nir" in mock_bi_calculator.source_bands
+    assert "red" in mock_bi_calculator.source_bands
+    assert "green" in mock_bi_calculator.source_bands
     assert mock_bi_calculator._output is None
 
 
@@ -49,15 +49,15 @@ def test_validate_method_exists(mock_bi_calculator):
 
 
 def test_process_calculates_bi_correctly(mock_bi_calculator):
-    mock_bi_calculator.normalized_bands = {
+    mock_bi_calculator.source_bands = {
         "nir": np.array([[0.5, 0.6], [0.7, 0.8]]),
         "red": np.array([[0.1, 0.2], [0.3, 0.4]]),
         "green": np.array([[0.05, 0.15], [0.25, 0.35]]),
     }
 
-    nir = mock_bi_calculator.normalized_bands["nir"]
-    red = mock_bi_calculator.normalized_bands["red"]
-    green = mock_bi_calculator.normalized_bands["green"]
+    nir = mock_bi_calculator.source_bands["nir"]
+    red = mock_bi_calculator.source_bands["red"]
+    green = mock_bi_calculator.source_bands["green"]
     expected = ((nir - green) - red) / ((nir + green) + red)
 
     result = mock_bi_calculator.process()
@@ -67,7 +67,7 @@ def test_process_calculates_bi_correctly(mock_bi_calculator):
 
 
 def test_process_handles_division_by_zero(mock_bi_calculator):
-    mock_bi_calculator.normalized_bands = {
+    mock_bi_calculator.source_bands = {
         "nir": np.zeros((100, 100)),
         "red": np.zeros((100, 100)),
         "green": np.zeros((100, 100)),
@@ -84,7 +84,7 @@ def test_process_handles_division_by_zero(mock_bi_calculator):
 
 
 def test_process_returns_correct_shape(mock_bi_calculator):
-    mock_bi_calculator.normalized_bands = {
+    mock_bi_calculator.source_bands = {
         "nir": np.random.rand(150, 200),
         "red": np.random.rand(150, 200),
         "green": np.random.rand(150, 200),

--- a/tests/tools/spectral_indices/ndvi_calculator_test.py
+++ b/tests/tools/spectral_indices/ndvi_calculator_test.py
@@ -10,18 +10,18 @@ from fezrs.tools.spectral_indices.ndvi_calculator import NDVICalculator
 
 @pytest.fixture
 def mock_ndvi_calculator():
-    fake_normalized_bands = {
+    fake_source_bands = {
         "nir": np.random.rand(100, 100),
         "red": np.random.rand(100, 100),
     }
 
     fake_files_handler = MagicMock()
-    fake_files_handler.get_normalized_bands.return_value = fake_normalized_bands
+    fake_files_handler.get_bands.return_value = fake_source_bands
 
     def fake_init(self, *args, **kwargs):
         self.files_handler = fake_files_handler
         self._output = None
-        self.normalized_bands = fake_normalized_bands
+        self.source_bands = fake_source_bands
 
     with patch(
         "fezrs.tools.spectral_indices.ndvi_calculator.BaseTool.__init__",
@@ -36,9 +36,9 @@ def mock_ndvi_calculator():
 
 
 def test_initialization(mock_ndvi_calculator):
-    assert mock_ndvi_calculator.normalized_bands is not None
-    assert "nir" in mock_ndvi_calculator.normalized_bands
-    assert "red" in mock_ndvi_calculator.normalized_bands
+    assert mock_ndvi_calculator.source_bands is not None
+    assert "nir" in mock_ndvi_calculator.source_bands
+    assert "red" in mock_ndvi_calculator.source_bands
     assert mock_ndvi_calculator._output is None
 
 
@@ -47,13 +47,13 @@ def test_validate_method_exists(mock_ndvi_calculator):
 
 
 def test_process_calculates_ndvi_correctly(mock_ndvi_calculator):
-    mock_ndvi_calculator.normalized_bands = {
+    mock_ndvi_calculator.source_bands = {
         "nir": np.array([[0.5, 0.6], [0.7, 0.8]]),
         "red": np.array([[0.1, 0.2], [0.3, 0.4]]),
     }
 
-    nir = mock_ndvi_calculator.normalized_bands["nir"]
-    red = mock_ndvi_calculator.normalized_bands["red"]
+    nir = mock_ndvi_calculator.source_bands["nir"]
+    red = mock_ndvi_calculator.source_bands["red"]
     expected = (nir - red) / (nir + red)
 
     result = mock_ndvi_calculator.process()
@@ -63,7 +63,7 @@ def test_process_calculates_ndvi_correctly(mock_ndvi_calculator):
 
 
 def test_process_handles_division_by_zero(mock_ndvi_calculator):
-    mock_ndvi_calculator.normalized_bands = {
+    mock_ndvi_calculator.source_bands = {
         "nir": np.zeros((100, 100)),
         "red": np.zeros((100, 100)),
     }
@@ -79,7 +79,7 @@ def test_process_handles_division_by_zero(mock_ndvi_calculator):
 
 
 def test_process_returns_correct_shape(mock_ndvi_calculator):
-    mock_ndvi_calculator.normalized_bands = {
+    mock_ndvi_calculator.source_bands = {
         "nir": np.random.rand(150, 200),
         "red": np.random.rand(150, 200),
     }
@@ -90,7 +90,7 @@ def test_process_returns_correct_shape(mock_ndvi_calculator):
 
 
 def test_ndvi_values_range(mock_ndvi_calculator):
-    mock_ndvi_calculator.normalized_bands = {
+    mock_ndvi_calculator.source_bands = {
         "nir": np.array([[1.0, 0.0], [0.5, 0.3]]),
         "red": np.array([[0.0, 1.0], [0.5, 0.9]]),
     }

--- a/tests/tools/spectral_indices/ndwi_calculator_test.py
+++ b/tests/tools/spectral_indices/ndwi_calculator_test.py
@@ -10,18 +10,18 @@ from fezrs.tools.spectral_indices.ndwi_calculator import NDWICalculator
 
 @pytest.fixture
 def mock_ndwi_calculator():
-    fake_normalized_bands = {
+    fake_source_bands = {
         "nir": np.random.rand(100, 100),
         "green": np.random.rand(100, 100),
     }
 
     fake_files_handler = MagicMock()
-    fake_files_handler.get_normalized_bands.return_value = fake_normalized_bands
+    fake_files_handler.get_bands.return_value = fake_source_bands
 
     def fake_init(self, *args, **kwargs):
         self.files_handler = fake_files_handler
         self._output = None
-        self.normalized_bands = fake_normalized_bands
+        self.source_bands = fake_source_bands
 
     with patch(
         "fezrs.tools.spectral_indices.ndwi_calculator.BaseTool.__init__",
@@ -36,9 +36,9 @@ def mock_ndwi_calculator():
 
 
 def test_initialization(mock_ndwi_calculator):
-    assert mock_ndwi_calculator.normalized_bands is not None
-    assert "nir" in mock_ndwi_calculator.normalized_bands
-    assert "green" in mock_ndwi_calculator.normalized_bands
+    assert mock_ndwi_calculator.source_bands is not None
+    assert "nir" in mock_ndwi_calculator.source_bands
+    assert "green" in mock_ndwi_calculator.source_bands
     assert mock_ndwi_calculator._output is None
 
 
@@ -47,13 +47,13 @@ def test_validate_method_exists(mock_ndwi_calculator):
 
 
 def test_process_calculates_ndwi_correctly(mock_ndwi_calculator):
-    mock_ndwi_calculator.normalized_bands = {
+    mock_ndwi_calculator.source_bands = {
         "nir": np.array([[0.5, 0.6], [0.7, 0.8]]),
         "green": np.array([[0.1, 0.2], [0.3, 0.4]]),
     }
 
-    nir = mock_ndwi_calculator.normalized_bands["nir"]
-    green = mock_ndwi_calculator.normalized_bands["green"]
+    nir = mock_ndwi_calculator.source_bands["nir"]
+    green = mock_ndwi_calculator.source_bands["green"]
     expected = (green - nir) / (nir + green)
 
     result = mock_ndwi_calculator.process()
@@ -63,7 +63,7 @@ def test_process_calculates_ndwi_correctly(mock_ndwi_calculator):
 
 
 def test_process_handles_division_by_zero(mock_ndwi_calculator):
-    mock_ndwi_calculator.normalized_bands = {
+    mock_ndwi_calculator.source_bands = {
         "nir": np.zeros((100, 100)),
         "green": np.zeros((100, 100)),
     }
@@ -79,7 +79,7 @@ def test_process_handles_division_by_zero(mock_ndwi_calculator):
 
 
 def test_process_returns_correct_shape(mock_ndwi_calculator):
-    mock_ndwi_calculator.normalized_bands = {
+    mock_ndwi_calculator.source_bands = {
         "nir": np.random.rand(150, 200),
         "green": np.random.rand(150, 200),
     }
@@ -90,7 +90,7 @@ def test_process_returns_correct_shape(mock_ndwi_calculator):
 
 
 def test_ndwi_values_range(mock_ndwi_calculator):
-    mock_ndwi_calculator.normalized_bands = {
+    mock_ndwi_calculator.source_bands = {
         "nir": np.array([[1.0, 0.0], [0.5, 0.3]]),
         "green": np.array([[0.0, 1.0], [0.5, 0.9]]),
     }

--- a/tests/tools/spectral_indices/radiometry_test.py
+++ b/tests/tools/spectral_indices/radiometry_test.py
@@ -1,0 +1,320 @@
+"""
+Radiometric behaviour of the spectral indices (issue #37).
+
+The indices previously read from ``get_normalized_bands()``, which min-max
+rescales each band independently. Because every band received a *different*
+affine transform, the relationships between bands were altered -- and those
+relationships are the entire physical content of a band ratio. Two consequences
+are tested here: a pixel's value depended on how much of the scene was loaded,
+and inter-band correlations inverted.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+
+from fezrs.tools.spectral_indices.afri_calculator import AFRICalculator
+from fezrs.tools.spectral_indices.ndvi_calculator import NDVICalculator
+from fezrs.tools.spectral_indices.savi_calculator import SAVICalculator
+from fezrs.utils.radiometry_handler import (
+    RADIOMETRIC_PRESETS,
+    apply_scaling,
+    warn_if_not_reflectance,
+)
+
+
+def _build(calculator_class, module_path, bands, **kwargs):
+    handler = MagicMock()
+    handler.get_bands.return_value = bands
+
+    def fake_init(self, *args, **inner):
+        self.files_handler = handler
+        self._output = None
+
+    with patch(f"{module_path}.BaseTool.__init__", fake_init):
+        return calculator_class(**kwargs)
+
+
+def _ndvi(bands, **kwargs):
+    return _build(
+        NDVICalculator,
+        "fezrs.tools.spectral_indices.ndvi_calculator",
+        bands,
+        nir_path="nir.tif",
+        red_path="red.tif",
+        **kwargs,
+    )
+
+
+# --- Scene independence -------------------------------------------------------
+
+
+def test_index_value_does_not_depend_on_loaded_extent():
+    """
+    The sharpest reproducibility failure in #37: under per-band min-max scaling
+    the same pixel produced a different NDVI depending on whether the full scene
+    or a crop was loaded, because the rescale used the extent's own extrema.
+    """
+    rng = np.random.default_rng(7)
+    nir = rng.integers(500, 6000, size=(64, 64)).astype(float)
+    red = rng.integers(200, 3000, size=(64, 64)).astype(float)
+
+    full = _ndvi({"nir": nir, "red": red}).process()
+    crop = _ndvi({"nir": nir[:16, :16], "red": red[:16, :16]}).process()
+
+    np.testing.assert_allclose(full[:16, :16], crop)
+
+
+def test_normalized_inputs_would_not_be_extent_independent():
+    """
+    Guards the reasoning above: the same comparison fails under the min-max
+    rescale the indices used to apply, so the test is not vacuous.
+    """
+    rng = np.random.default_rng(7)
+    nir = rng.integers(500, 6000, size=(64, 64)).astype(float)
+    red = rng.integers(200, 3000, size=(64, 64)).astype(float)
+
+    def normalize(a):
+        return (a - a.min()) / (a.max() - a.min())
+
+    def ndvi(n, r):
+        return (n - r) / (n + r)
+
+    full = ndvi(normalize(nir), normalize(red))
+    crop = ndvi(normalize(nir[:16, :16]), normalize(red[:16, :16]))
+
+    assert not np.allclose(full[:16, :16], crop)
+
+
+def test_normalized_difference_is_invariant_to_a_common_gain():
+    """
+    A normalized difference is insensitive to a gain applied to every band
+    equally -- which is why NDVI on raw DN is still meaningful, unlike SAVI.
+    """
+    nir = np.array([[0.5, 0.6]])
+    red = np.array([[0.1, 0.2]])
+
+    plain = _ndvi({"nir": nir, "red": red}).process()
+    gained = _ndvi({"nir": nir * 10000, "red": red * 10000}).process()
+
+    np.testing.assert_allclose(plain, gained)
+
+
+EXAMPLE_DATA = Path(__file__).resolve().parents[3] / "example" / "data"
+
+
+def _read_example_band(name):
+    rasterio = pytest.importorskip("rasterio")
+    path = EXAMPLE_DATA / f"{name}.tif"
+    if not path.is_file():
+        pytest.skip(f"bundled example band {name} not available")
+    with rasterio.open(path) as source:
+        return source.read(1).astype(float)
+
+
+def _correlate(a, b):
+    mask = np.isfinite(a) & np.isfinite(b)
+    return float(np.corrcoef(a[mask], b[mask])[0, 1])
+
+
+def test_afri_tracks_ndvi_on_real_bands():
+    """
+    Karnieli et al. (2001) report that under clear-sky conditions AFRI and NDVI
+    values are "almost identical". That gives an independent physical check on
+    the pipeline, and it needs genuinely correlated bands -- synthetic noise has
+    no spectral structure to preserve or destroy.
+
+    On the bundled Landsat subset the relationship holds on values as read and
+    inverts under the per-band min-max rescale the indices used to apply, which
+    is the measurement behind issue #37.
+    """
+    nir = _read_example_band("nir")
+    red = _read_example_band("red")
+    swir1 = _read_example_band("swir_1")
+
+    def normalize(a):
+        return (a - a.min()) / (a.max() - a.min())
+
+    ndvi = (nir - red) / (nir + red)
+    afri = (nir - 0.66 * swir1) / (nir + 0.66 * swir1)
+
+    afri_normalized = (normalize(nir) - 0.66 * normalize(swir1)) / (
+        normalize(nir) + 0.66 * normalize(swir1)
+    )
+    ndvi_normalized = (normalize(nir) - normalize(red)) / (
+        normalize(nir) + normalize(red)
+    )
+
+    # As read: the physically expected agreement.
+    assert _correlate(afri, ndvi) > 0.5
+    # Per-band rescaled: the sign flips, so the two disagree about the scene.
+    assert _correlate(afri_normalized, ndvi_normalized) < 0
+
+
+def test_bsi_opposes_vegetation_on_real_bands():
+    """
+    Bare ground and canopy are inverse surface types, so BSI must correlate
+    negatively with NDVI. Under per-band rescaling that correlation turns
+    positive, i.e. the index reports bare ground where vegetation is.
+    """
+    nir = _read_example_band("nir")
+    red = _read_example_band("red")
+    blue = _read_example_band("blue")
+    swir1 = _read_example_band("swir_1")
+
+    def normalize(a):
+        return (a - a.min()) / (a.max() - a.min())
+
+    def bsi(s, r, n, b):
+        return ((s + r) - (n + b)) / ((s + r) + (n + b))
+
+    ndvi = (nir - red) / (nir + red)
+
+    assert _correlate(bsi(swir1, red, nir, blue), ndvi) < 0
+    assert (
+        _correlate(
+            bsi(normalize(swir1), normalize(red), normalize(nir), normalize(blue)),
+            (normalize(nir) - normalize(red)) / (normalize(nir) + normalize(red)),
+        )
+        > 0
+    )
+
+
+# --- Radiometric scaling ------------------------------------------------------
+
+
+def test_scaling_converts_landsat_c2l2_integers_to_reflectance():
+    digital_numbers = np.array([[10000.0, 20000.0]])
+
+    scaled = apply_scaling(
+        {"nir": digital_numbers}, **RADIOMETRIC_PRESETS["landsat-c2-l2"]
+    )
+
+    expected = digital_numbers * 2.75e-5 - 0.2
+    np.testing.assert_allclose(scaled["nir"], expected)
+    assert 0.0 <= scaled["nir"].min() <= 1.0
+
+
+def test_identity_scaling_leaves_values_untouched():
+    bands = {"nir": np.array([[1.0, 2.0]])}
+
+    scaled = apply_scaling(bands, scale_factor=1.0, offset=0.0)
+
+    np.testing.assert_allclose(scaled["nir"], bands["nir"])
+
+
+def test_calculator_applies_scaling_before_computing():
+    nir = np.array([[20000.0]])
+    red = np.array([[10000.0]])
+
+    calculator = _ndvi(
+        {"nir": nir, "red": red}, **RADIOMETRIC_PRESETS["landsat-c2-l2"]
+    )
+    result = calculator.process()
+
+    nir_reflectance = nir * 2.75e-5 - 0.2
+    red_reflectance = red * 2.75e-5 - 0.2
+    expected = (nir_reflectance - red_reflectance) / (
+        nir_reflectance + red_reflectance
+    )
+
+    np.testing.assert_allclose(result, expected)
+
+
+def test_savi_warns_when_given_unscaled_digital_numbers():
+    """
+    SAVI's L = 0.5 is defined in reflectance units. Added to a DN in the
+    thousands it contributes nothing, so the result is silently not SAVI.
+    """
+    bands = {
+        "nir": np.array([[4200.0, 5100.0]]),
+        "red": np.array([[1200.0, 1500.0]]),
+    }
+
+    with pytest.warns(UserWarning, match="outside the reflectance range"):
+        _build(
+            SAVICalculator,
+            "fezrs.tools.spectral_indices.savi_calculator",
+            bands,
+            nir_path="nir.tif",
+            red_path="red.tif",
+        )
+
+
+def test_afri_warns_when_given_unscaled_digital_numbers():
+    bands = {
+        "nir": np.array([[4200.0]]),
+        "swir1": np.array([[2600.0]]),
+    }
+
+    with pytest.warns(UserWarning, match="outside the reflectance range"):
+        _build(
+            AFRICalculator,
+            "fezrs.tools.spectral_indices.afri_calculator",
+            bands,
+            nir_path="nir.tif",
+            swir1_path="swir1.tif",
+        )
+
+
+def test_no_warning_once_scaling_is_supplied():
+    bands = {
+        "nir": np.array([[20000.0]]),
+        "red": np.array([[10000.0]]),
+    }
+
+    with _no_warnings():
+        _build(
+            SAVICalculator,
+            "fezrs.tools.spectral_indices.savi_calculator",
+            bands,
+            nir_path="nir.tif",
+            red_path="red.tif",
+            **RADIOMETRIC_PRESETS["landsat-c2-l2"],
+        )
+
+
+def test_gain_invariant_indices_do_not_warn():
+    """
+    NDVI carries no reflectance-scale constant, so unscaled input is legitimate
+    and must not raise a warning.
+    """
+    bands = {
+        "nir": np.array([[4200.0]]),
+        "red": np.array([[1200.0]]),
+    }
+
+    with _no_warnings():
+        _ndvi(bands)
+
+
+def test_warning_helper_ignores_gain_invariant_indices():
+    bands = {"nir": np.array([[9999.0]])}
+
+    with _no_warnings():
+        warn_if_not_reflectance(bands, "NDVI")
+
+
+class _no_warnings:
+    """Assert that no UserWarning is emitted inside the block."""
+
+    def __enter__(self):
+        import warnings
+
+        self._manager = warnings.catch_warnings(record=True)
+        self._records = self._manager.__enter__()
+        warnings.simplefilter("always")
+        return self
+
+    def __exit__(self, *exc_info):
+        offending = [
+            record
+            for record in self._records
+            if issubclass(record.category, UserWarning)
+            and "reflectance range" in str(record.message)
+        ]
+        self._manager.__exit__(*exc_info)
+        assert not offending, f"unexpected warnings: {offending}"
+        return False

--- a/tests/tools/spectral_indices/reference_values_test.py
+++ b/tests/tools/spectral_indices/reference_values_test.py
@@ -41,7 +41,7 @@ BANDS = {
 def _build(calculator_class, module_path, **kwargs):
     """Instantiate a calculator with BaseTool.__init__ patched out."""
     handler = MagicMock()
-    handler.get_normalized_bands.return_value = BANDS
+    handler.get_bands.return_value = BANDS
 
     def fake_init(self, *args, **inner):
         self.files_handler = handler
@@ -50,7 +50,7 @@ def _build(calculator_class, module_path, **kwargs):
     with patch(f"{module_path}.BaseTool.__init__", fake_init):
         calculator = calculator_class(**kwargs)
 
-    calculator.normalized_bands = BANDS
+    calculator.source_bands = BANDS
     return calculator
 
 
@@ -281,7 +281,7 @@ def test_bsi_separates_bare_ground_from_vegetation():
         "nir": np.array([[0.55, 0.28]]),
         "blue": np.array([[0.02, 0.20]]),
     }
-    handler.get_normalized_bands.return_value = vegetation_then_rock
+    handler.get_bands.return_value = vegetation_then_rock
 
     def fake_init(self, *args, **kwargs):
         self.files_handler = handler
@@ -296,7 +296,7 @@ def test_bsi_separates_bare_ground_from_vegetation():
             swir1_path="swir1.tif",
             blue_path="blue.tif",
         )
-    calculator.normalized_bands = vegetation_then_rock
+    calculator.source_bands = vegetation_then_rock
 
     output = calculator.process()
 

--- a/tests/tools/spectral_indices/savi_calculator_test.py
+++ b/tests/tools/spectral_indices/savi_calculator_test.py
@@ -9,18 +9,18 @@ from fezrs.tools.spectral_indices.savi_calculator import SAVICalculator
 
 @pytest.fixture
 def mock_savi_calculator():
-    fake_normalized_bands = {
+    fake_source_bands = {
         "nir": np.random.rand(100, 100),
         "red": np.random.rand(100, 100),
     }
 
     fake_files_handler = MagicMock()
-    fake_files_handler.get_normalized_bands.return_value = fake_normalized_bands
+    fake_files_handler.get_bands.return_value = fake_source_bands
 
     def fake_init(self, *args, **kwargs):
         self.files_handler = fake_files_handler
         self._output = None
-        self.normalized_bands = fake_normalized_bands
+        self.source_bands = fake_source_bands
 
     with patch(
         "fezrs.tools.spectral_indices.savi_calculator.BaseTool.__init__",
@@ -35,9 +35,9 @@ def mock_savi_calculator():
 
 
 def test_initialization(mock_savi_calculator):
-    assert mock_savi_calculator.normalized_bands is not None
-    assert "nir" in mock_savi_calculator.normalized_bands
-    assert "red" in mock_savi_calculator.normalized_bands
+    assert mock_savi_calculator.source_bands is not None
+    assert "nir" in mock_savi_calculator.source_bands
+    assert "red" in mock_savi_calculator.source_bands
     assert mock_savi_calculator._output is None
 
 
@@ -46,13 +46,13 @@ def test_validate_method_exists(mock_savi_calculator):
 
 
 def test_process_calculates_savi_correctly(mock_savi_calculator):
-    mock_savi_calculator.normalized_bands = {
+    mock_savi_calculator.source_bands = {
         "nir": np.array([[0.5, 0.6], [0.7, 0.8]]),
         "red": np.array([[0.1, 0.2], [0.3, 0.4]]),
     }
 
-    nir = mock_savi_calculator.normalized_bands["nir"]
-    red = mock_savi_calculator.normalized_bands["red"]
+    nir = mock_savi_calculator.source_bands["nir"]
+    red = mock_savi_calculator.source_bands["red"]
     expected = ((nir - red) / (nir + red + 0.5)) * 1.5
 
     result = mock_savi_calculator.process()
@@ -62,7 +62,7 @@ def test_process_calculates_savi_correctly(mock_savi_calculator):
 
 
 def test_process_handles_division_by_zero(mock_savi_calculator):
-    mock_savi_calculator.normalized_bands = {
+    mock_savi_calculator.source_bands = {
         "nir": np.full((100, 100), -0.25),
         "red": np.full((100, 100), -0.25),
     }
@@ -78,7 +78,7 @@ def test_process_handles_division_by_zero(mock_savi_calculator):
 
 
 def test_process_returns_correct_shape(mock_savi_calculator):
-    mock_savi_calculator.normalized_bands = {
+    mock_savi_calculator.source_bands = {
         "nir": np.random.rand(150, 200),
         "red": np.random.rand(150, 200),
     }

--- a/tests/tools/spectral_indices/ui_calculator_test.py
+++ b/tests/tools/spectral_indices/ui_calculator_test.py
@@ -10,18 +10,18 @@ from fezrs.tools.spectral_indices.ui_calculator import UICalculator
 
 @pytest.fixture
 def mock_ui_calculator():
-    fake_normalized_bands = {
+    fake_source_bands = {
         "nir": np.random.rand(100, 100),
         "swir2": np.random.rand(100, 100),
     }
 
     fake_files_handler = MagicMock()
-    fake_files_handler.get_normalized_bands.return_value = fake_normalized_bands
+    fake_files_handler.get_bands.return_value = fake_source_bands
 
     def fake_init(self, *args, **kwargs):
         self.files_handler = fake_files_handler
         self._output = None
-        self.normalized_bands = fake_normalized_bands
+        self.source_bands = fake_source_bands
 
     with patch(
         "fezrs.tools.spectral_indices.ui_calculator.BaseTool.__init__",
@@ -36,9 +36,9 @@ def mock_ui_calculator():
 
 
 def test_initialization(mock_ui_calculator):
-    assert mock_ui_calculator.normalized_bands is not None
-    assert "nir" in mock_ui_calculator.normalized_bands
-    assert "swir2" in mock_ui_calculator.normalized_bands
+    assert mock_ui_calculator.source_bands is not None
+    assert "nir" in mock_ui_calculator.source_bands
+    assert "swir2" in mock_ui_calculator.source_bands
     assert mock_ui_calculator._output is None
 
 
@@ -47,13 +47,13 @@ def test_validate_method_exists(mock_ui_calculator):
 
 
 def test_process_calculates_ui_correctly(mock_ui_calculator):
-    mock_ui_calculator.normalized_bands = {
+    mock_ui_calculator.source_bands = {
         "nir": np.array([[0.5, 0.6], [0.7, 0.8]]),
         "swir2": np.array([[0.1, 0.2], [0.3, 0.4]]),
     }
 
-    nir = mock_ui_calculator.normalized_bands["nir"]
-    swir2 = mock_ui_calculator.normalized_bands["swir2"]
+    nir = mock_ui_calculator.source_bands["nir"]
+    swir2 = mock_ui_calculator.source_bands["swir2"]
     expected = (swir2 - nir) / (nir + swir2)
 
     result = mock_ui_calculator.process()
@@ -63,7 +63,7 @@ def test_process_calculates_ui_correctly(mock_ui_calculator):
 
 
 def test_process_handles_division_by_zero(mock_ui_calculator):
-    mock_ui_calculator.normalized_bands = {
+    mock_ui_calculator.source_bands = {
         "nir": np.zeros((100, 100)),
         "swir2": np.zeros((100, 100)),
     }
@@ -79,7 +79,7 @@ def test_process_handles_division_by_zero(mock_ui_calculator):
 
 
 def test_process_returns_correct_shape(mock_ui_calculator):
-    mock_ui_calculator.normalized_bands = {
+    mock_ui_calculator.source_bands = {
         "nir": np.random.rand(150, 200),
         "swir2": np.random.rand(150, 200),
     }
@@ -90,7 +90,7 @@ def test_process_returns_correct_shape(mock_ui_calculator):
 
 
 def test_ui_values_range(mock_ui_calculator):
-    mock_ui_calculator.normalized_bands = {
+    mock_ui_calculator.source_bands = {
         "nir": np.array([[1.0, 0.0], [0.5, 0.3]]),
         "swir2": np.array([[0.0, 1.0], [0.5, 0.9]]),
     }


### PR DESCRIPTION
Stacked on #51 — review #50 and #51 first; this PR targets `hotfix/afri-formula`.

## Problem

All six index calculators read from `FileHandler.get_normalized_bands()`:

```python
(image - np.min(image)) / (np.max(image) - np.min(image))
```

applied **independently to each band**. Each band therefore receives a *different* affine transform, which changes the relationships *between* bands — and those relationships are the entire physical content of a spectral index. `(NIR' - Red') / (NIR' + Red')` where NIR' and Red' were rescaled by different factors is simply not NDVI.

Reproduced on `example/data/`:

| | before | after |
|---|---|---|
| NDVI mean | 0.3351 | **0.5103** |
| pixels NDVI > 0.3 | 55.64% | **59.88%** |
| max abs difference vs rasterio reference | 0.7453 | **0.0** |
| same pixel, full scene vs 400×400 crop | 0.8373 / 0.8692 | **identical** |
| AFRI vs NDVI correlation | −0.6927 | **+0.7117** |
| BSI vs NDVI correlation | +0.3908 | **−0.6507** |

The last two are the ones I find most telling. Karnieli et al. report AFRI and NDVI as "almost identical" under clear sky, and bare ground must oppose canopy. Both relationships held on the stored values and **inverted** under the rescale — the index was not merely rescaled, it was reporting the opposite of the physical truth. Those are the two indices whose formulas #51 just corrected; they only start behaving correctly here.

The extent dependence is the reproducibility failure: loading a crop changed the answer for pixels the crop shared with the full scene.

## Changes

**1. Indices compute on values as read.** New `FileHandler.get_bands()` returns the arrays already held in `self.bands`, mirroring the existing accessor pattern. The six calculators switch to it; `self.normalized_bands` becomes `self.source_bands`.

Min–max normalization is **untouched** for the enhancement, HSV, PCA and SVM modules, where rescaling is appropriate — and for SVM it is genuinely required, since an RBF kernel needs comparable feature scales.

**2. Radiometric scaling, because removing the rescale is not sufficient on its own.** It leaves the indices computing on digital numbers, and two of them carry constants defined in reflectance units:

| Index | Constant | Safe on raw DN? |
|---|---|---|
| NDVI, NDWI, UI, BSI | none | **Yes** — invariant to a gain applied to all bands equally |
| SAVI | soil adjustment `L = 0.5` | **No** |
| AFRI | coefficients 0.66 / 0.50 on SWIR | **No** |

Adding `L = 0.5` to a DN in the thousands contributes nothing, so SAVI on unscaled input is silently not SAVI. Every index now accepts `scale_factor`/`offset`, applied as `ρ = DN × s + o`, with published values for the common analysis-ready products shipped as `RADIOMETRIC_PRESETS`:

```python
SAVICalculator(nir_path=..., red_path=..., **RADIOMETRIC_PRESETS["landsat-c2-l2"])
```

Covering Landsat C2 L2 (`2.75e-5`, `−0.2`), Sentinel-2 L2A (`1e-4`, `0`), and Sentinel-2 L2A baseline ≥ 04.00 (`1e-4`, `−0.1`, for the `BOA_ADD_OFFSET` introduced in that baseline). SAVI and AFRI emit a `UserWarning` when handed values far outside the reflectance range, so the silent-nonsense case becomes loud.

## Behaviour change

Index values change for every user — deliberately, and documented prominently in `docs/spectral-indices.md`. The previous values were scene-dependent and not the cited indices, so preserving them would preserve the defect. Defaults are `scale_factor=1.0, offset=0.0`, so input already in reflectance needs nothing passed.

## Tests

347 pass (334 on #51, 13 new). `tests/tools/spectral_indices/radiometry_test.py` covers:

- **Extent invariance** — a pixel's NDVI is identical for the full array and a crop containing it, plus a companion test asserting the same comparison *fails* under min–max, so the first is not vacuous.
- **Gain invariance** — NDVI unchanged when all bands are multiplied by 10000, the property that makes normalized differences safe on DN.
- **Physical relationships on the bundled Landsat subset** — AFRI must track NDVI (> 0.5) and BSI must oppose it (< 0), with both asserted to invert under per-band rescaling. These read the real bands via rasterio and skip if unavailable; synthetic noise has no spectral structure to preserve, so this property can only be tested on genuinely correlated bands. My first attempt used random arrays and was measuring nothing.
- Scaling arithmetic, calculator-level application, and the SAVI/AFRI warnings firing on DN while NDVI stays silent.

The six existing index test fixtures were updated from `get_normalized_bands`/`normalized_bands` to `get_bands`/`source_bands`.
