### PR TITLE
FIX SVM click-simulation tests failing on headless CI

### DIFF
--- a/tests/tools/svm/svm_calculator_test.py
+++ b/tests/tools/svm/svm_calculator_test.py
@@ -308,20 +308,26 @@ def _run_process_with_clicks(calculator, clicks):
             return 0
         return 27
 
-    with patch("fezrs.tools.svm.svm_calculator.cv2.namedWindow"):
-        with patch(
-            "fezrs.tools.svm.svm_calculator.cv2.setMouseCallback",
-            fake_set_mouse_callback,
-        ):
-            with patch("fezrs.tools.svm.svm_calculator.cv2.imshow"):
-                with patch(
-                    "fezrs.tools.svm.svm_calculator.cv2.waitKey",
-                    fake_wait_key,
-                ):
+    # The GUI is fully mocked here, so the display check must be forced on:
+    # otherwise these tests pass on a workstation and fail on headless CI.
+    with patch(
+        "fezrs.tools.svm.svm_calculator.display_is_available",
+        return_value=True,
+    ):
+        with patch("fezrs.tools.svm.svm_calculator.cv2.namedWindow"):
+            with patch(
+                "fezrs.tools.svm.svm_calculator.cv2.setMouseCallback",
+                fake_set_mouse_callback,
+            ):
+                with patch("fezrs.tools.svm.svm_calculator.cv2.imshow"):
                     with patch(
-                        "fezrs.tools.svm.svm_calculator.cv2.destroyAllWindows"
+                        "fezrs.tools.svm.svm_calculator.cv2.waitKey",
+                        fake_wait_key,
                     ):
-                        calculator.process()
+                        with patch(
+                            "fezrs.tools.svm.svm_calculator.cv2.destroyAllWindows"
+                        ):
+                            calculator.process()
 
 
 def test_nonsquare_training_samples_use_opencv_xy_as_numpy_yx():


### PR DESCRIPTION
Fixes the red `FEZrs Tests` run on `main` ([run 32463258511](https://github.com/FEZtool-team/FEZrs/actions/runs/32463258511/job/96714743097)).

## What broke

```
FAILED tests/tools/svm/svm_calculator_test.py::test_nonsquare_training_samples_use_opencv_xy_as_numpy_yx
FAILED tests/tools/svm/svm_calculator_test.py::test_nonsquare_output_shape_and_pixel_order
RuntimeError: SVMCalculator needs training_samples when no display is available.
```

My fault, from the non-interactive SVM PR. That PR added a display check in front of the OpenCV window so a headless run raises a catchable error instead of Qt aborting the process. These two pre-existing tests drive the interactive path with **every `cv2` entry point mocked** — but not `display_is_available()`. The guard runs before any of the mocked calls, so:

- **workstation**: `DISPLAY` is set → guard passes → mocked window runs → tests pass
- **CI runner**: no `DISPLAY` → guard raises → `process()` never reaches the simulated clicks → tests fail

I updated `test_process_creates_rgb_stack` for exactly this when I changed its ESC behaviour, but missed these two because they live in a separate helper further down the file and passed locally.

## Fix

Force the display check on inside `_run_process_with_clicks`, matching what the ESC test already does. The helper mocks the entire GUI, so whether a real display exists is irrelevant to what these tests assert.

Test-only change. No library behaviour is affected, and the guard itself is unchanged.

## Verification

Ran the full suite under `env -u DISPLAY -u WAYLAND_DISPLAY`, which reproduces the CI environment:

```
headless:      421 passed
with display:  421 passed
```

Previously headless gave 2 failures. Worth noting for future changes to this module: a plain local `pytest` run does **not** exercise the headless path, so anything touching the display guard should be checked with `DISPLAY` unset.
