### PR TITLE
FIX remaining dependency declarations and repair the conda recipe (#43)

### DIFF
--- a/recip/meta.yaml
+++ b/recip/meta.yaml
@@ -14,17 +14,24 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python >=3.11
     - pip
     - setuptools
     - opencv
+  # Must cover everything `import fezrs` loads. Previously this listed fastapi,
+  # which the package does not use, while omitting pandas, rasterio, pillow and
+  # imagecodecs, all of which are imported at package import time - so a conda
+  # install failed on `import fezrs` with ModuleNotFoundError: rasterio.
   run:
-    - python >=3.10
+    - python >=3.11
     - numpy
+    - pillow
+    - pandas
+    - rasterio
     - matplotlib
-    - scikit-image
+    - imagecodecs
     - scikit-learn
-    - fastapi
+    - scikit-image
     - opencv
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
-pytest==9.0.3
+# Test-only. Runtime dependencies live in requirements.txt.
+pytest>=8.0

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -3,7 +3,6 @@
 numpy==2.4.6
 Pillow==12.2.0
 pandas==3.0.3
-pydantic==2.13.4
 rasterio==1.5.0
 matplotlib==3.10.9
 imagecodecs==2026.5.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,18 @@
+# Lower bounds, not exact pins: FEZrs is a library and has to coexist with the
+# numpy / rasterio / scikit-learn a user's environment already has. Add an upper
+# bound only for a known, documented incompatibility.
+# Exact versions for reproducible installs live in requirements-lock.txt.
 numpy>=1.26
 Pillow>=10.0
 pandas>=2.0
-pydantic>=2.0
 rasterio>=1.3
 matplotlib>=3.8
-imagecodecs>=2023.1.1
 scikit-learn>=1.3
 scikit-image>=0.22
 opencv-python>=4.8
+
+# Not imported by FEZrs directly, but loaded at `import fezrs` time through
+# scikit-image/tifffile, and required to decode compressed (LZW, deflate, JPEG)
+# GeoTIFFs on the input path. The bundled example data is uncompressed; most
+# real Landsat and Sentinel deliveries are not.
+imagecodecs>=2023.1.1

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,11 @@ setup(
     url="https://github.com/FEZtool-team/FEZrs",
     classifiers=[
         "Programming Language :: Python :: 3",
+        # Kept in step with the CI matrix in .github/workflows/FEZrs_Tests.yml,
+        # so the advertised support is the support that is actually tested.
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],

--- a/tests/setup_test.py
+++ b/tests/setup_test.py
@@ -96,3 +96,159 @@ def test_downstream_publish_workflows_chain_off_pypi_dispatch():
     for workflow in (conda, citation):
         assert "github.event.workflow_run.event == 'push'" in workflow
         assert "github.event.workflow_run.event == 'workflow_dispatch'" in workflow
+
+
+# --- Declared dependencies match reality (issue #43) --------------------------
+
+
+def _requirement_names(path):
+    """Distribution names from a requirements file, bounds and comments stripped."""
+    names = []
+    for line in (PROJECT_ROOT / path).read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        for separator in (">=", "==", "<=", "~=", ">", "<"):
+            if separator in line:
+                line = line.split(separator)[0]
+                break
+        names.append(line.strip())
+    return names
+
+
+def test_every_runtime_requirement_is_actually_loaded():
+    """
+    `pydantic` was published as a runtime dependency while appearing nowhere in
+    the codebase. Importing the package in a clean interpreter and checking what
+    it pulls in catches that, while still allowing genuinely transitive
+    dependencies such as imagecodecs, which arrives via scikit-image/tifffile
+    and is what decodes compressed GeoTIFFs.
+    """
+    import subprocess
+
+    # Distribution name -> the top-level module it provides.
+    module_of = {
+        "Pillow": "PIL",
+        "opencv-python": "cv2",
+        "scikit-learn": "sklearn",
+        "scikit-image": "skimage",
+    }
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys, fezrs; "
+            "print(' '.join(sorted({m.split('.')[0] for m in sys.modules})))",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    loaded = set(result.stdout.split())
+
+    unused = [
+        name
+        for name in _requirement_names("requirements.txt")
+        if module_of.get(name, name) not in loaded
+    ]
+
+    assert not unused, (
+        f"declared as runtime dependencies but never loaded by `import fezrs`: "
+        f"{unused}"
+    )
+
+
+def test_lock_file_covers_the_same_distributions_as_requirements():
+    """Same distributions, order irrelevant."""
+    assert set(_requirement_names("requirements-lock.txt")) == set(
+        _requirement_names("requirements.txt")
+    )
+
+
+def test_lock_file_is_exactly_pinned():
+    """The lock file is the counterpart to the loosened bounds; it must pin."""
+    lines = [
+        line.strip()
+        for line in (PROJECT_ROOT / "requirements-lock.txt")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+    assert lines and all("==" in line for line in lines)
+
+
+def test_dev_requirements_are_test_only():
+    """
+    gdal, pyrsgis and tensorflow were declared here but imported nowhere, and
+    tensorflow alone is several hundred megabytes for anyone following
+    CONTRIBUTING.md to run the suite.
+    """
+    names = _requirement_names("requirements-dev.txt")
+
+    assert "pytest" in names
+    for heavy in ("gdal", "pyrsgis", "tensorflow"):
+        assert heavy not in names
+
+
+def test_conda_recipe_covers_every_runtime_dependency():
+    """
+    The recipe declared fastapi, which the package does not use, and omitted
+    pandas, rasterio, pillow and imagecodecs, so `import fezrs` failed after a
+    conda install.
+    """
+    recipe = (PROJECT_ROOT / "recip" / "meta.yaml").read_text(encoding="utf-8")
+    run_block = recipe.split("run:", 1)[1].split("about:", 1)[0]
+    declared = {
+        line.strip().lstrip("- ").split()[0].lower()
+        for line in run_block.splitlines()
+        if line.strip().startswith("- ")
+    }
+
+    # conda channel names differ from the PyPI distribution names.
+    conda_name = {
+        "opencv-python": "opencv",
+        "pillow": "pillow",
+    }
+    required = {
+        conda_name.get(name.lower(), name.lower())
+        for name in _requirement_names("requirements.txt")
+    }
+
+    assert required <= declared, f"missing from conda recipe: {sorted(required - declared)}"
+    assert "fastapi" not in declared
+
+
+def test_conda_recipe_python_matches_setup_py(monkeypatch):
+    recipe = (PROJECT_ROOT / "recip" / "meta.yaml").read_text(encoding="utf-8")
+
+    assert "python >=3.11" in recipe
+    assert "python >=3.10" not in recipe
+
+
+def test_classifiers_cover_the_tested_python_versions(monkeypatch):
+    captured_setup_kwargs = {}
+
+    monkeypatch.chdir(PROJECT_ROOT)
+    monkeypatch.setitem(
+        sys.modules,
+        "setuptools",
+        SimpleNamespace(
+            setup=lambda **kwargs: captured_setup_kwargs.update(kwargs),
+            find_packages=lambda include=None: ["fezrs"],
+        ),
+    )
+    runpy.run_path(str(PROJECT_ROOT / "setup.py"))
+
+    workflow = (
+        PROJECT_ROOT / ".github" / "workflows" / "FEZrs_Tests.yml"
+    ).read_text(encoding="utf-8")
+    classifiers = captured_setup_kwargs["classifiers"]
+
+    for version in ("3.11", "3.12", "3.13"):
+        assert f'"{version}"' in workflow, f"{version} missing from the CI matrix"
+        assert (
+            f"Programming Language :: Python :: {version}" in classifiers
+        ), f"{version} tested but not advertised in setup.py classifiers"


### PR DESCRIPTION
Completes issue #43. Most of it already landed in `1a753dc` — lower bounds, the dev-dependency cleanup, and the 3 OS × 3 Python matrix. Three declarations were still wrong, and one of them breaks an advertised install route.

## 1. `pydantic` was still published as a runtime dependency

It is imported nowhere. This is the same defect the issue reports for the dev requirements, and it survived the earlier loosening because only the version specifier changed (`==2.13.4` → `>=2.0`), not the entry itself. Removed from `requirements.txt` and `requirements-lock.txt`.

## 2. The conda recipe was never updated, and the conda install is broken

`recip/meta.yaml` declares `fastapi` — which the package does not use — while **omitting `pandas`, `rasterio`, `pillow` and `imagecodecs`**, all of which are loaded at `import fezrs` time:

```
imported at `import fezrs` time: PIL cv2 imagecodecs matplotlib numpy pandas rasterio skimage sklearn
conda recipe provides         : cv2 matplotlib numpy skimage sklearn
MISSING from conda recipe     : PIL imagecodecs pandas rasterio
```

So `conda install -c FEZtool fezrs` followed by `import fezrs` fails with `ModuleNotFoundError: rasterio`. The recipe also declared `python >=3.10` against `setup.py`'s `>=3.11`. All corrected. The README advertises conda as one of two install routes, so this belongs with the packaging fix.

I left the recipe's run dependencies unversioned, matching its existing style — I have no conda toolchain here to test a solve against, and adding bounds I cannot verify seemed the riskier change. The new test asserts the *set* of names stays in step with `requirements.txt`.

## 3. Smaller items

`requirements-dev.txt` still pinned `pytest==9.0.3` exactly, which is the pattern this issue is about; reproducible installs are what `requirements-lock.txt` is for. Now `pytest>=8.0`.

`setup.py` gains 3.11/3.12/3.13 classifiers, so advertised support matches the matrix rather than being implied by `python_requires` alone.

## On `imagecodecs`

Worth stating explicitly since it looks like another unused dependency: it is **not** imported by FEZrs code, but it *is* loaded at `import fezrs` time through scikit-image/tifffile, and it is what decodes compressed (LZW, deflate, JPEG) GeoTIFFs on the input path. The bundled example data is uncompressed; most real Landsat and Sentinel deliveries are not. Kept, and the reason is now a comment in `requirements.txt` rather than something to rediscover.

## Guards

`tests/setup_test.py` gains seven tests so none of this regresses silently:

- every declared runtime requirement must actually be loaded by `import fezrs`, checked in a clean subprocess — this is the guard that would have caught `pydantic`, and it still allows legitimately transitive dependencies like `imagecodecs`;
- the lock file must cover the same distributions as `requirements.txt` and stay exactly pinned;
- the dev file must stay test-only (explicitly asserting `gdal`/`pyrsgis`/`tensorflow` do not return);
- the conda recipe must cover every runtime dependency, must not declare `fastapi`, and must agree with `setup.py` on the Python floor;
- classifiers must list every Python version in the CI matrix.

## Verification

Built three environments with `uv` and ran the full suite headless in each:

| Python | resolved rasterio | result |
|---|---|---|
| 3.11.15 | **1.4.4** | 436 passed, 1 skipped |
| 3.12.13 | 1.5.1 | 437 passed |
| 3.13.14 | 1.5.1 | 436 passed, 1 skipped |

(The skip is `importorskip("setuptools")` in the docs-import test; those two environments have no setuptools.)

The 3.11 row is the point of the whole issue. `rasterio==1.5.0` declares `requires_python >=3.12` and ships no cp311 wheel, so `python_requires=">=3.11"` could not be satisfied under the old pins — the advertised support was unreachable. With lower bounds the resolver picks 1.4.4 there and the suite passes.

Published metadata now reads:

```
['numpy>=1.26', 'Pillow>=10.0', 'pandas>=2.0', 'rasterio>=1.3', 'matplotlib>=3.8',
 'scikit-learn>=1.3', 'scikit-image>=0.22', 'opencv-python>=4.8', 'imagecodecs>=2023.1.1']
```

Also worth noting the loosened bounds resolve *forward*, not just backward: on 3.12 they pull numpy 2.5.2, opencv 5.0.0 and scikit-learn 1.9.0 — all newer than the lock file — and the suite is green on those too. That is the upstream-breakage signal a lockfile-only setup would have hidden.
